### PR TITLE
fix: allow creation of asset with owner identified by UUID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ vendor/
 config.yaml
 compass.yaml
 temp/
+.playground/

--- a/internal/store/postgres/asset_repository.go
+++ b/internal/store/postgres/asset_repository.go
@@ -611,31 +611,31 @@ func (r *AssetRepository) getOwners(ctx context.Context, assetID string) (owners
 }
 
 // insertOwners inserts relation of asset id and user id
-func (r *AssetRepository) insertOwners(ctx context.Context, execer sqlx.ExecerContext, assetID string, owners []user.User) (err error) {
+func (r *AssetRepository) insertOwners(ctx context.Context, execer sqlx.ExecerContext, assetID string, owners []user.User) error {
 	if len(owners) == 0 {
-		return
+		return nil
 	}
 
 	if !isValidUUID(assetID) {
 		return asset.InvalidError{AssetID: assetID}
 	}
 
-	var values []string
-	var args = []interface{}{assetID}
-	for i, owner := range owners {
-		values = append(values, fmt.Sprintf("($1, $%d)", i+2))
-		args = append(args, owner.ID)
-	}
-	query := fmt.Sprintf(`
-		INSERT INTO asset_owners
-			(asset_id, user_id)
-		VALUES %s`, strings.Join(values, ","))
-	err = r.execContext(ctx, execer, query, args...)
-	if err != nil {
-		err = fmt.Errorf("error running insert owners query: %w", err)
+	sqlb := sq.Insert("asset_owners").
+		Columns("asset_id", "user_id")
+	for _, o := range owners {
+		sqlb = sqlb.Values(assetID, o.ID)
 	}
 
-	return
+	qry, args, err := sqlb.PlaceholderFormat(sq.Dollar).ToSql()
+	if err != nil {
+		return fmt.Errorf("build insert owners SQL: %w", err)
+	}
+
+	if err := r.execContext(ctx, execer, qry, args...); err != nil {
+		return fmt.Errorf("error running insert owners query: %w", err)
+	}
+
+	return nil
 }
 
 func (r *AssetRepository) removeOwners(ctx context.Context, execer sqlx.ExecerContext, assetID string, owners []user.User) (err error) {
@@ -695,34 +695,38 @@ func (r *AssetRepository) compareOwners(current, newOwners []user.User) (toInser
 	return
 }
 
-func (r *AssetRepository) createOrFetchUsers(ctx context.Context, tx *sqlx.Tx, users []user.User) (results []user.User, err error) {
+func (r *AssetRepository) createOrFetchUsers(ctx context.Context, tx *sqlx.Tx, users []user.User) ([]user.User, error) {
+	var results []user.User
 	for _, u := range users {
+		var (
+			userID      string
+			fetchedUser user.User
+			err         error
+		)
 		if u.UUID != "" {
-			results = append(results, u)
-			continue
+			fetchedUser, err = r.userRepo.GetByUUID(ctx, u.UUID)
+		} else {
+			fetchedUser, err = r.userRepo.GetByEmail(ctx, u.Email)
 		}
-		var userID string
-		var fetchedUser user.User
-		fetchedUser, err = r.userRepo.GetByEmail(ctx, u.Email)
-		userID = fetchedUser.ID
+		if err == nil {
+			userID = fetchedUser.ID
+		}
 		if errors.As(err, &user.NotFoundError{}) {
 			u.Provider = r.defaultUserProvider
 			userID, err = r.userRepo.CreateWithTx(ctx, tx, &u)
 			if err != nil {
-				err = fmt.Errorf("error creating owner: %w", err)
-				return
+				return nil, fmt.Errorf("error creating owner: %w", err)
 			}
 		}
 		if err != nil {
-			err = fmt.Errorf("error getting owner's ID: %w", err)
-			return
+			return nil, fmt.Errorf("error getting owner's ID: %w", err)
 		}
 
 		u.ID = userID
 		results = append(results, u)
 	}
 
-	return
+	return results, nil
 }
 
 func (r *AssetRepository) execContext(ctx context.Context, execer sqlx.ExecerContext, query string, args ...interface{}) error {

--- a/internal/store/postgres/asset_repository_test.go
+++ b/internal/store/postgres/asset_repository_test.go
@@ -951,8 +951,8 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				Type:    "table",
 				Service: "bigquery",
 				Owners: []user.User{
-					r.users[1],
-					r.users[2],
+					stripUserID(r.users[1]),
+					{Email: r.users[2].Email},
 				},
 				UpdatedBy: r.users[0],
 			}
@@ -966,9 +966,8 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 			r.NoError(err)
 
 			r.Len(actual.Owners, len(ast.Owners))
-			for i, owner := range actual.Owners {
-				r.Equal(ast.Owners[i].ID, owner.ID)
-			}
+			r.Equal(r.users[1].ID, actual.Owners[0].ID)
+			r.Equal(r.users[2].ID, actual.Owners[1].ID)
 		})
 
 		r.Run("should create owners as users if they do not exist yet", func() {
@@ -977,7 +976,8 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				Type:    "table",
 				Service: "bigquery",
 				Owners: []user.User{
-					{Email: "newuser@example.com", Provider: defaultProviderName},
+					{Email: "newuser@example.com"},
+					{UUID: "795151e5-4c9f-4951-a8e1-6966b5aa2bb6"},
 				},
 				UpdatedBy: r.users[0],
 			}
@@ -990,10 +990,8 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 			r.NoError(err)
 
 			r.Len(actual.Owners, len(ast.Owners))
-			for i, owner := range actual.Owners {
-				r.Equal(ast.Owners[i].Email, owner.Email)
-				r.NotEmpty(id)
-			}
+			r.Equal(ast.Owners[0].Email, actual.Owners[0].Email)
+			r.Equal(ast.Owners[1].UUID, actual.Owners[1].UUID)
 		})
 	})
 
@@ -1056,14 +1054,14 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				Type:    "table",
 				Service: "bigquery",
 				Owners: []user.User{
-					r.users[1],
-					r.users[2],
+					stripUserID(r.users[1]),
+					stripUserID(r.users[2]),
 				},
 				UpdatedBy: r.users[0],
 			}
 			newAsset := ast
 			newAsset.Owners = []user.User{
-				r.users[2],
+				stripUserID(r.users[2]),
 			}
 
 			id, err := r.repository.Upsert(r.ctx, &ast)
@@ -1079,9 +1077,7 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 			actual, err := r.repository.GetByID(r.ctx, ast.ID)
 			r.NoError(err)
 			r.Len(actual.Owners, len(newAsset.Owners))
-			for i, owner := range actual.Owners {
-				r.Equal(newAsset.Owners[i].ID, owner.ID)
-			}
+			r.Equal(r.users[2].ID, actual.Owners[0].ID)
 		})
 
 		r.Run("should create new owners if it does not exist on old asset", func() {
@@ -1090,14 +1086,14 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				Type:    "table",
 				Service: "bigquery",
 				Owners: []user.User{
-					r.users[1],
+					stripUserID(r.users[1]),
 				},
 				UpdatedBy: r.users[0],
 			}
 			newAsset := ast
 			newAsset.Owners = []user.User{
-				r.users[1],
-				r.users[2],
+				stripUserID(r.users[1]),
+				stripUserID(r.users[2]),
 			}
 
 			id, err := r.repository.Upsert(r.ctx, &ast)
@@ -1113,9 +1109,8 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 			actual, err := r.repository.GetByID(r.ctx, ast.ID)
 			r.NoError(err)
 			r.Len(actual.Owners, len(newAsset.Owners))
-			for i, owner := range actual.Owners {
-				r.Equal(newAsset.Owners[i].ID, owner.ID)
-			}
+			r.Equal(r.users[1].ID, actual.Owners[0].ID)
+			r.Equal(r.users[2].ID, actual.Owners[1].ID)
 		})
 
 		r.Run("should create users from owners if owner emails do not exist yet", func() {
@@ -1124,14 +1119,14 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				Type:    "table",
 				Service: "bigquery",
 				Owners: []user.User{
-					r.users[1],
+					stripUserID(r.users[1]),
 				},
 				UpdatedBy: r.users[0],
 			}
 			newAsset := ast
 			newAsset.Owners = []user.User{
-				r.users[1],
-				{Email: "newuser@example.com", Provider: defaultProviderName},
+				stripUserID(r.users[1]),
+				{Email: "newuser@example.com"},
 			}
 
 			id, err := r.repository.Upsert(r.ctx, &ast)
@@ -1147,10 +1142,10 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 			actual, err := r.repository.GetByID(r.ctx, ast.ID)
 			r.NoError(err)
 			r.Len(actual.Owners, len(newAsset.Owners))
-			for i, owner := range actual.Owners {
-				r.Equal(newAsset.Owners[i].Email, owner.Email)
-				r.NotEmpty(id)
-			}
+			r.NotEmpty(actual.Owners[0].ID)
+			r.Equal(r.users[1].ID, actual.Owners[0].ID)
+			r.NotEmpty(actual.Owners[1].ID)
+			r.Equal(newAsset.Owners[1].Email, actual.Owners[1].Email)
 		})
 	})
 }
@@ -1829,4 +1824,9 @@ func (r *AssetRepositoryTestSuite) assertProbe(t *testing.T, expected asset.Prob
 
 func TestAssetRepository(t *testing.T) {
 	suite.Run(t, &AssetRepositoryTestSuite{})
+}
+
+func stripUserID(u user.User) user.User {
+	u.ID = ""
+	return u
 }


### PR DESCRIPTION
- Fix create asset failure with owner(s) identified by UUID by fetching the Compass native user ID for the given UUID. Create the user if no user exists for the given UUID.
- Refactor SQL for inserting owners to use squirrel SQL builder.

Closes #5 