### PR TITLE
fix(discovery): search universe index alias instead of _all

### DIFF
--- a/core/asset/errors.go
+++ b/core/asset/errors.go
@@ -3,6 +3,7 @@ package asset
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 var (
@@ -36,9 +37,24 @@ func (err InvalidError) Error() string {
 }
 
 type DiscoveryError struct {
-	Err error
+	Op    string
+	ID    string
+	Index string
+	Err   error
 }
 
 func (err DiscoveryError) Error() string {
-	return fmt.Sprintf("discovery error: %s", err.Err)
+	var s strings.Builder
+	s.WriteString("discovery error: ")
+	if err.Op != "" {
+		s.WriteString(err.Op + ": ")
+	}
+	if err.ID != "" {
+		s.WriteString("doc ID '" + err.ID + "': ")
+	}
+	if err.Index != "" {
+		s.WriteString("index '" + err.Index + "': ")
+	}
+	s.WriteString(err.Err.Error())
+	return s.String()
 }

--- a/internal/store/elasticsearch/discovery_repository_test.go
+++ b/internal/store/elasticsearch/discovery_repository_test.go
@@ -59,6 +59,44 @@ func TestDiscoveryRepositoryUpsert(t *testing.T) {
 		assert.ErrorIs(t, err, asset.ErrUnknownType)
 	})
 
+	t.Run("should return error if response.body.Errors is true", func(t *testing.T) {
+		cli, err := esTestServer.NewClient()
+		require.NoError(t, err)
+		esClient, err := store.NewClient(
+			log.NewNoop(),
+			store.Config{},
+			store.WithClient(cli),
+		)
+		require.NoError(t, err)
+
+		repo := store.NewDiscoveryRepository(esClient)
+
+		// upsert with create_time as a object
+		err = repo.Upsert(ctx, asset.Asset{
+			ID:      "sample-id",
+			Type:    asset.TypeTable,
+			Service: bigqueryService,
+			Data: map[string]interface{}{
+				"create_time": map[string]interface{}{
+					"seconds": 1618103237,
+					"nanos":   897000000,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// upsert with create_time as a string
+		err = repo.Upsert(ctx, asset.Asset{
+			ID:      "sample-id",
+			Type:    asset.TypeTable,
+			Service: bigqueryService,
+			Data: map[string]interface{}{
+				"create_time": "2023-04-10T22:33:57.897Z",
+			},
+		})
+		assert.EqualError(t, err, "discovery error: IndexDoc: doc ID 'sample-id': index 'bigquery-test': object mapping for [data.create_time] tried to parse field [create_time] as object, but found a concrete value")
+	})
+
 	t.Run("should insert asset to the correct index by its service", func(t *testing.T) {
 		ast := asset.Asset{
 			ID:          "sample-id",

--- a/internal/store/elasticsearch/discovery_search_repository_test.go
+++ b/internal/store/elasticsearch/discovery_search_repository_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/goto/compass/core/asset"
 	store "github.com/goto/compass/internal/store/elasticsearch"
 	"github.com/goto/salt/log"
@@ -47,7 +48,7 @@ func TestSearcherSearch(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		err = loadTestFixture(esClient, "./testdata/search-test-fixture.json")
+		err = loadTestFixture(cli, esClient, "./testdata/search-test-fixture.json")
 		require.NoError(t, err)
 
 		repo := store.NewDiscoveryRepository(esClient)
@@ -219,7 +220,7 @@ func TestSearcherSuggest(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = loadTestFixture(esClient, "./testdata/suggest-test-fixture.json")
+	err = loadTestFixture(cli, esClient, "./testdata/suggest-test-fixture.json")
 	require.NoError(t, err)
 
 	repo := store.NewDiscoveryRepository(esClient)
@@ -245,7 +246,7 @@ func TestSearcherSuggest(t *testing.T) {
 	})
 }
 
-func loadTestFixture(esClient *store.Client, filePath string) (err error) {
+func loadTestFixture(cli *elasticsearch.Client, esClient *store.Client, filePath string) (err error) {
 	testFixtureJSON, err := os.ReadFile(filePath)
 	if err != nil {
 		return
@@ -266,6 +267,11 @@ func loadTestFixture(esClient *store.Client, filePath string) (err error) {
 			}
 		}
 	}
+
+	_, err = cli.Indices.Refresh(
+		cli.Indices.Refresh.WithIgnoreUnavailable(true),
+		cli.Indices.Refresh.WithIndex("universe"),
+	)
 
 	return err
 }


### PR DESCRIPTION
- Run search queries against the 'universe' index alias instead of _all.
- During the asset upsert in discovery repo, use a single index operation instead of the bulk update. Avoid triggering a refresh for each update as it can be quite costly.
- Improve contextual information in error for discovery repository update and delete operations.
- Always drain the response body in discovery repo to help with connection reuse.