### PR TITLE
fix(discovery): ignore unavailable indices for delete by query

### DIFF
--- a/internal/store/elasticsearch/discovery_repository.go
+++ b/internal/store/elasticsearch/discovery_repository.go
@@ -109,11 +109,13 @@ func (repo *DiscoveryRepository) DeleteByURN(ctx context.Context, assetURN strin
 }
 
 func (repo *DiscoveryRepository) deleteWithQuery(ctx context.Context, qry string) error {
-	res, err := repo.cli.client.DeleteByQuery(
+	deleteByQ := repo.cli.client.DeleteByQuery
+	res, err := deleteByQ(
 		[]string{defaultSearchIndex},
 		strings.NewReader(qry),
-		repo.cli.client.DeleteByQuery.WithContext(ctx),
-		repo.cli.client.DeleteByQuery.WithRefresh(true),
+		deleteByQ.WithContext(ctx),
+		deleteByQ.WithRefresh(true),
+		deleteByQ.WithIgnoreUnavailable(true),
 	)
 	if err != nil {
 		return asset.DiscoveryError{


### PR DESCRIPTION
If there are closed indices with the 'universe' alias, unless we add the option to ignore unavailable indices, the delete operation fails with an error.

Add the ignore unavailable option for delete by ID/URN in discovery repository so that closed indices are ignored.

Closes #15. 