### PR TITLE
fix: set created_at, updated_at fields before update in repo

### DIFF
--- a/internal/store/postgres/asset_repository_test.go
+++ b/internal/store/postgres/asset_repository_test.go
@@ -936,6 +936,8 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 			r.Equal(asset.BaseVersion, ast.Version)
 			r.NoError(err)
 			r.NotEmpty(id)
+			r.NotEmpty(ast.CreatedAt)
+			r.NotEmpty(ast.UpdatedAt)
 			ast.ID = id
 
 			assetInDB, err := r.repository.GetByID(r.ctx, ast.ID)
@@ -948,6 +950,7 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 			ast2.Description = "create a new version" // to force fetch from asset_versions.
 			_, err = r.repository.Upsert(r.ctx, &ast2)
 			r.NoError(err)
+			r.Greater(ast2.UpdatedAt.UnixNano(), ast.UpdatedAt.UnixNano())
 			assetv1, err := r.repository.GetByVersionWithID(r.ctx, ast.ID, asset.BaseVersion)
 			r.NoError(err)
 			r.Equal("0.1", assetv1.Version)


### PR DESCRIPTION
These fields are saved to datastores in assets_versions table as well as the discovery repository. Populating the fields during insert/update ensures that the timestamps are synced across tables and datastores for a given asset.