### PR TITLE
fix: asset versions sort order

### DIFF
--- a/internal/store/postgres/asset_repository.go
+++ b/internal/store/postgres/asset_repository.go
@@ -175,7 +175,7 @@ func (r *AssetRepository) GetVersionHistory(ctx context.Context, flt asset.Filte
 
 	builder := r.getAssetVersionSQL().
 		Where(sq.Eq{"a.asset_id": id}).
-		OrderBy("version DESC").
+		OrderBy("string_to_array(version, '.')::int[] DESC").
 		Limit(uint64(size)).
 		Offset(uint64(flt.Offset))
 	query, args, err := r.buildSQL(builder)


### PR DESCRIPTION
Fix sort order in asset versions response, don't sort version field as string. Without the fix, for an asset with 99 versions on applying the filter `{Size: 3, Offset: 86}`, expected versions = `{0.13, 0.12, 0.11}` but actual versions = `{0.20, 0.2, 0.19}`.