### PR TITLE
fix: Elasticsearch index settings - ignore-malformed

### DIFF
--- a/internal/store/elasticsearch/schema.go
+++ b/internal/store/elasticsearch/schema.go
@@ -9,6 +9,7 @@ var indexSettingsTemplate = `{
 		%q: {}
 	},
 	"settings": {
+		"index.mapping.ignore_malformed": true,
 		"analysis": {
 			"analyzer": {
 				"my_analyzer": {

--- a/internal/store/elasticsearch/testdata/search-test-fixture.json
+++ b/internal/store/elasticsearch/testdata/search-test-fixture.json
@@ -13,7 +13,8 @@
                     "company": "gotocompany",
                     "environment": "integration",
                     "country": "us",
-                    "partition": 250
+                    "partition": 250,
+                    "malformed": "2023-05-23T04:35:42Z"
                 },
                 "type": "topic"
             },
@@ -29,7 +30,8 @@
                     "company": "microsoft",
                     "environment": "integration",
                     "country": "id",
-                    "partition": 100
+                    "partition": 100,
+                    "malformed": ""
                 },
                 "type": "topic"
             },


### PR DESCRIPTION
See
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/ignore-malformed.html