### PR TITLE
fix: address subset of golangci-lint issues

### DIFF
--- a/cli/assets.go
+++ b/cli/assets.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/goto/compass/internal/client"
 	compassv1beta1 "github.com/goto/compass/proto/gotocompany/compass/v1beta1"
-	"github.com/goto/salt/term"
-
-	"github.com/MakeNowJust/heredoc"
 	"github.com/goto/salt/printer"
+	"github.com/goto/salt/term"
 	"github.com/spf13/cobra"
 )
 
@@ -94,7 +93,6 @@ func listAllAssetsCommand(cfg *Config) *cobra.Command {
 				Size:      size,
 				Offset:    page,
 			})
-
 			if err != nil {
 				return err
 			}
@@ -209,7 +207,6 @@ func editAssetCommand(cfg *Config) *cobra.Command {
 				Asset:     reqBody.Asset,
 				Upstreams: reqBody.Upstreams,
 			})
-
 			if err != nil {
 				return err
 			}
@@ -298,7 +295,6 @@ func listAllTypesCommand(cfg *Config) *cobra.Command {
 				Services: services,
 				Data:     data,
 			})
-
 			if err != nil {
 				return err
 			}

--- a/cli/config.go
+++ b/cli/config.go
@@ -59,7 +59,7 @@ func configInitCommand() *cobra.Command {
 }
 
 func configListCommand(cfg *Config) *cobra.Command {
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List server and client configuration settings",
 		Example: heredoc.Doc(`

--- a/cli/discussions.go
+++ b/cli/discussions.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/goto/compass/internal/client"
 	compassv1beta1 "github.com/goto/compass/proto/gotocompany/compass/v1beta1"
 	"github.com/goto/salt/printer"
 	"github.com/goto/salt/term"
-
-	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 )
 
@@ -166,7 +165,6 @@ func postDiscussionCommand(cfg *Config) *cobra.Command {
 				Labels: reqBody.Labels,
 				Assets: reqBody.Assets,
 			})
-
 			if err != nil {
 				return err
 			}

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -6,8 +6,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 )
 
-var (
-	ErrConfigNotFound = errors.New(heredoc.Doc(`
+var ErrConfigNotFound = errors.New(heredoc.Doc(`
 	Config file not found. Loading from defaults...
 
 	Run "compass config init" to initialize a new configuartion file 
@@ -15,4 +14,3 @@ var (
 
 	Alternatively, make a "compass.yaml" file in the current directory from the example given
 `))
-)

--- a/cli/root.go
+++ b/cli/root.go
@@ -31,7 +31,6 @@ var rootCmd = &cobra.Command{
 }
 
 func New(cliConfig *Config) *cobra.Command {
-
 	if cliConfig.Client.ServerHeaderKeyUUID == "" {
 		cliConfig.Client.ServerHeaderKeyUUID = cliConfig.Service.Identity.HeaderKeyUUID
 	}

--- a/cli/server.go
+++ b/cli/server.go
@@ -51,7 +51,6 @@ func serverCmd(cfg *Config) *cobra.Command {
 }
 
 func serverStartCommand(cfg *Config) *cobra.Command {
-
 	c := &cobra.Command{
 		Use:     "start",
 		Short:   "Start server on default port 8080",
@@ -66,7 +65,6 @@ func serverStartCommand(cfg *Config) *cobra.Command {
 }
 
 func serverMigrateCommand(cfg *Config) *cobra.Command {
-
 	c := &cobra.Command{
 		Use:   "migrate",
 		Short: "Run storage migration",

--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -15,8 +15,8 @@ type Repository interface {
 	GetByID(ctx context.Context, id string) (Asset, error)
 	GetByURN(ctx context.Context, urn string) (Asset, error)
 	GetVersionHistory(ctx context.Context, flt Filter, id string) ([]Asset, error)
-	GetByVersionWithID(ctx context.Context, id string, version string) (Asset, error)
-	GetByVersionWithURN(ctx context.Context, urn string, version string) (Asset, error)
+	GetByVersionWithID(ctx context.Context, id, version string) (Asset, error)
+	GetByVersionWithURN(ctx context.Context, urn, version string) (Asset, error)
 	GetTypes(ctx context.Context, flt Filter) (map[Type]int, error)
 	Upsert(ctx context.Context, ast *Asset) (string, error)
 	DeleteByID(ctx context.Context, id string) error

--- a/core/asset/asset_test.go
+++ b/core/asset/asset_test.go
@@ -72,7 +72,6 @@ func TestDiffTopLevel(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-
 			var sourceAsset asset.Asset
 			err := json.Unmarshal([]byte(tc.Source), &sourceAsset)
 			if err != nil {
@@ -237,7 +236,6 @@ func TestDiffData(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-
 			var sourceAsset asset.Asset
 			err := json.Unmarshal([]byte(tc.Source), &sourceAsset)
 			if err != nil {
@@ -367,7 +365,8 @@ func TestAssetPatch(t *testing.T) {
 					{Email: "new2@example.com"},
 				},
 			},
-		}, {
+		},
+		{
 			description: "should patch all allowed fields without labels and owners",
 			asset: asset.Asset{
 				URN:         "some-urn",

--- a/core/asset/discovery_test.go
+++ b/core/asset/discovery_test.go
@@ -14,7 +14,7 @@ func TestToAsset(t *testing.T) {
 		Expect       asset.Asset
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title: "should return correct asset",
 			SearchResult: asset.SearchResult{

--- a/core/asset/filter_test.go
+++ b/core/asset/filter_test.go
@@ -13,7 +13,7 @@ func TestValidateFilter(t *testing.T) {
 		Filter      *asset.Filter
 		errString   string
 	}
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: "empty filter will be valid",
 			Filter:      &asset.Filter{},
@@ -57,7 +57,7 @@ func TestBuild(t *testing.T) {
 		Services      string
 		QFields       string
 	}
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: "invalid size and offset will return error",
 			Size:        -12,

--- a/core/asset/patch.go
+++ b/core/asset/patch.go
@@ -29,28 +29,28 @@ func patchAsset(a *Asset, patchData map[string]interface{}) {
 }
 
 // buildLabels builds labels from interface{}
-func buildLabels(data interface{}) (labels map[string]string) {
+func buildLabels(data interface{}) map[string]string {
+	var labels map[string]string
 	switch d := data.(type) {
 	case map[string]interface{}:
 		labels = map[string]string{}
 		for key, value := range d {
-			stringVal, ok := value.(string)
+			s, ok := value.(string)
 			if !ok {
 				continue
 			}
-			labels[key] = stringVal
+			labels[key] = s
 		}
+
 	case map[string]string:
 		labels = d
-	default:
-		labels = nil
 	}
 
-	return
+	return labels
 }
 
 // buildOwners builds owners from interface{}
-func buildOwners(data interface{}) (owners []user.User) {
+func buildOwners(data interface{}) []user.User {
 	buildOwner := func(data map[string]interface{}) user.User {
 		return user.User{
 			ID:       getString("id", data),
@@ -60,9 +60,9 @@ func buildOwners(data interface{}) (owners []user.User) {
 		}
 	}
 
+	var owners []user.User
 	switch d := data.(type) {
 	case []interface{}:
-		owners = []user.User{}
 		for _, value := range d {
 			mapValue, ok := value.(map[string]interface{})
 			if !ok {
@@ -71,17 +71,14 @@ func buildOwners(data interface{}) (owners []user.User) {
 			owners = append(owners, buildOwner(mapValue))
 		}
 	case []map[string]interface{}:
-		owners = []user.User{}
 		for _, value := range d {
 			owners = append(owners, buildOwner(value))
 		}
 	case []user.User:
 		owners = d
-	default:
-		owners = nil
 	}
 
-	return
+	return owners
 }
 
 // patchAssetData patches asset's data using map

--- a/core/asset/service.go
+++ b/core/asset/service.go
@@ -86,28 +86,33 @@ func (s *Service) DeleteAsset(ctx context.Context, id string) error {
 	return s.lineageRepository.DeleteByURN(ctx, id)
 }
 
-func (s *Service) GetAssetByID(ctx context.Context, id string) (ast Asset, err error) {
+func (s *Service) GetAssetByID(ctx context.Context, id string) (Asset, error) {
+	var ast Asset
 	if isValidUUID(id) {
-		if ast, err = s.assetRepository.GetByID(ctx, id); err != nil {
-			return Asset{}, fmt.Errorf("error when getting asset by id: %w", err)
+		var err error
+		ast, err = s.assetRepository.GetByID(ctx, id)
+		if err != nil {
+			return Asset{}, fmt.Errorf("get asset by id: %w", err)
 		}
 	} else {
-		if ast, err = s.assetRepository.GetByURN(ctx, id); err != nil {
-			return Asset{}, fmt.Errorf("error when getting asset by urn: %w", err)
+		var err error
+		ast, err = s.assetRepository.GetByURN(ctx, id)
+		if err != nil {
+			return Asset{}, fmt.Errorf("get asset by urn: %w", err)
 		}
 	}
 
 	probes, err := s.assetRepository.GetProbes(ctx, ast.URN)
 	if err != nil {
-		return Asset{}, fmt.Errorf("error when getting probes: %w", err)
+		return Asset{}, fmt.Errorf("get probes: %w", err)
 	}
 
 	ast.Probes = probes
 
-	return
+	return ast, nil
 }
 
-func (s *Service) GetAssetByVersion(ctx context.Context, id string, version string) (Asset, error) {
+func (s *Service) GetAssetByVersion(ctx context.Context, id, version string) (Asset, error) {
 	if isValidUUID(id) {
 		return s.assetRepository.GetByVersionWithID(ctx, id, version)
 	}

--- a/core/asset/service_test.go
+++ b/core/asset/service_test.go
@@ -23,7 +23,7 @@ func TestService_GetAllAssets(t *testing.T) {
 		Setup       func(context.Context, *mocks.AssetRepository, *mocks.DiscoveryRepository, *mocks.LineageRepository)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return error if asset repository get all return error and with total false`,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
@@ -112,7 +112,7 @@ func TestService_GetTypes(t *testing.T) {
 		Setup       func(context.Context, *mocks.AssetRepository)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return error if asset repository get types return error`,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository) {
@@ -173,7 +173,7 @@ func TestService_UpsertAsset(t *testing.T) {
 		Setup       func(context.Context, *mocks.AssetRepository, *mocks.DiscoveryRepository, *mocks.LineageRepository)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
@@ -245,7 +245,7 @@ func TestService_UpsertAsset(t *testing.T) {
 
 func TestService_UpsertAssetWithoutLineage(t *testing.T) {
 	sampleAsset := &asset.Asset{ID: "some-id", URN: "some-urn", Type: asset.TypeDashboard, Service: "some-service"}
-	var testCases = []struct {
+	testCases := []struct {
 		Description string
 		Asset       *asset.Asset
 		Err         error
@@ -311,7 +311,7 @@ func TestService_DeleteAsset(t *testing.T) {
 		Setup       func(context.Context, *mocks.AssetRepository, *mocks.DiscoveryRepository, *mocks.LineageRepository)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `with ID, should return error if asset repository get by id returns error`,
 			ID:          assetID,
@@ -435,7 +435,7 @@ func TestService_GetAssetByID(t *testing.T) {
 		ID: assetID,
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return error if the repository return error without id`,
 			ID:          assetID,
@@ -551,7 +551,7 @@ func TestService_GetAssetByVersion(t *testing.T) {
 		Setup       func(context.Context, *mocks.AssetRepository)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return error if the GetByVersionWithID function return error`,
 			ID:          assetID,
@@ -615,7 +615,7 @@ func TestService_GetAssetVersionHistory(t *testing.T) {
 	}
 
 	ast := []asset.Asset{}
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return error if the GetVersionHistory function return error`,
 			ID:          assetID,
@@ -663,7 +663,7 @@ func TestService_GetLineage(t *testing.T) {
 		Err         error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return error if the GetGraph function return error`,
 			ID:          assetID,
@@ -814,7 +814,7 @@ func TestService_SearchSuggestGroupAssets(t *testing.T) {
 
 	searchResults := []asset.SearchResult{}
 	groupResults := []asset.GroupResult{}
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return error if the GetGraph function return error`,
 			ID:          assetID,

--- a/core/discussion/discussion.go
+++ b/core/discussion/discussion.go
@@ -20,9 +20,9 @@ type Repository interface {
 	Patch(ctx context.Context, discussion *Discussion) error
 	GetAllComments(ctx context.Context, discussionID string, filter Filter) ([]Comment, error)
 	CreateComment(ctx context.Context, cmt *Comment) (string, error)
-	GetComment(ctx context.Context, commentID string, discussionID string) (Comment, error)
+	GetComment(ctx context.Context, commentID, discussionID string) (Comment, error)
 	UpdateComment(ctx context.Context, cmt *Comment) error
-	DeleteComment(ctx context.Context, commentID string, discussionID string) error
+	DeleteComment(ctx context.Context, commentID, discussionID string) error
 }
 
 type Discussion struct {

--- a/core/discussion/discussion_test.go
+++ b/core/discussion/discussion_test.go
@@ -16,7 +16,7 @@ func TestIsEmpty(t *testing.T) {
 		IsEmpty     bool
 	}
 
-	var testCases = []TestCase{
+	testCases := []TestCase{
 		{
 			Description: "all necessary fields are empty and nil will be considered empty",
 			Discussion:  discussion.Discussion{ID: "123", CreatedAt: time.Now(), UpdatedAt: time.Now()},
@@ -77,7 +77,7 @@ func TestValidateConstraint(t *testing.T) {
 		Err         error
 	}
 
-	var testCases = []TestCase{
+	testCases := []TestCase{
 		{
 			Description: "type is not one of supported types will return error",
 			Discussion:  discussion.Discussion{Type: "random"},
@@ -122,7 +122,7 @@ func TestValidateDiscussion(t *testing.T) {
 		Err         error
 	}
 
-	var testCases = []TestCase{
+	testCases := []TestCase{
 		{
 			Description: "empty title will return error",
 			Discussion:  discussion.Discussion{},

--- a/core/discussion/filter_test.go
+++ b/core/discussion/filter_test.go
@@ -15,7 +15,7 @@ func TestValidateFilter(t *testing.T) {
 		errString   string
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: "empty filter will be valid",
 			Filter:      &discussion.Filter{},
@@ -59,7 +59,7 @@ func TestAssignDefault(t *testing.T) {
 		ExpectedFilter *discussion.Filter
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: "non empty fields in filter won't be changed",
 			Filter: &discussion.Filter{

--- a/core/discussion/service.go
+++ b/core/discussion/service.go
@@ -15,27 +15,35 @@ type Service struct {
 func (s *Service) GetDiscussions(ctx context.Context, filter Filter) ([]Discussion, error) {
 	return s.discussionRepository.GetAll(ctx, filter)
 }
+
 func (s *Service) CreateDiscussion(ctx context.Context, dsc *Discussion) (string, error) {
 	return s.discussionRepository.Create(ctx, dsc)
 }
+
 func (s *Service) GetDiscussion(ctx context.Context, did string) (Discussion, error) {
 	return s.discussionRepository.Get(ctx, did)
 }
+
 func (s *Service) PatchDiscussion(ctx context.Context, dsc *Discussion) error {
 	return s.discussionRepository.Patch(ctx, dsc)
 }
+
 func (s *Service) GetComments(ctx context.Context, discussionID string, filter Filter) ([]Comment, error) {
 	return s.discussionRepository.GetAllComments(ctx, discussionID, filter)
 }
+
 func (s *Service) CreateComment(ctx context.Context, cmt *Comment) (string, error) {
 	return s.discussionRepository.CreateComment(ctx, cmt)
 }
-func (s *Service) GetComment(ctx context.Context, commentID string, discussionID string) (Comment, error) {
+
+func (s *Service) GetComment(ctx context.Context, commentID, discussionID string) (Comment, error) {
 	return s.discussionRepository.GetComment(ctx, commentID, discussionID)
 }
+
 func (s *Service) UpdateComment(ctx context.Context, cmt *Comment) error {
 	return s.discussionRepository.UpdateComment(ctx, cmt)
 }
-func (s *Service) DeleteComment(ctx context.Context, commentID string, discussionID string) error {
+
+func (s *Service) DeleteComment(ctx context.Context, commentID, discussionID string) error {
 	return s.discussionRepository.DeleteComment(ctx, commentID, discussionID)
 }

--- a/core/discussion/state_test.go
+++ b/core/discussion/state_test.go
@@ -15,7 +15,7 @@ func TestState(t *testing.T) {
 			Result      string
 		}
 
-		var testCases = []TestCase{
+		testCases := []TestCase{
 			{
 				Description: "state open converts to \"open\"",
 				State:       discussion.StateOpen,
@@ -46,7 +46,7 @@ func TestState(t *testing.T) {
 			Result      discussion.State
 		}
 
-		var testCases = []TestCase{
+		testCases := []TestCase{
 			{
 				Description: "\"open\" converts to state open",
 				StateString: "open",
@@ -77,7 +77,7 @@ func TestState(t *testing.T) {
 			IsValid     bool
 		}
 
-		var testCases = []TestCase{
+		testCases := []TestCase{
 			{
 				Description: "supported state will return valid true",
 				StateString: "open",

--- a/core/discussion/type_test.go
+++ b/core/discussion/type_test.go
@@ -15,7 +15,7 @@ func TestType(t *testing.T) {
 			Result      string
 		}
 
-		var testCases = []TestCase{
+		testCases := []TestCase{
 			{
 				Description: "type openended converts to \"openended\"",
 				Type:        discussion.TypeOpenEnded,
@@ -51,7 +51,7 @@ func TestType(t *testing.T) {
 			Result      discussion.Type
 		}
 
-		var testCases = []TestCase{
+		testCases := []TestCase{
 			{
 				Description: "\"openended\" converts to type openended",
 				TypeString:  "openended",
@@ -87,7 +87,7 @@ func TestType(t *testing.T) {
 			IsValid     bool
 		}
 
-		var testCases = []TestCase{
+		testCases := []TestCase{
 			{
 				Description: "supported type will return valid true",
 				TypeString:  "openended",

--- a/core/star/service.go
+++ b/core/star/service.go
@@ -20,15 +20,19 @@ type Service struct {
 func (s *Service) GetStarredAssetsByUserID(ctx context.Context, flt Filter, userID string) ([]asset.Asset, error) {
 	return s.starRepository.GetAllAssetsByUserID(ctx, flt, userID)
 }
+
 func (s *Service) GetStarredAssetByUserID(ctx context.Context, userID, assetID string) (asset.Asset, error) {
 	return s.starRepository.GetAssetByUserID(ctx, userID, assetID)
 }
+
 func (s *Service) GetStargazers(ctx context.Context, flt Filter, assetID string) ([]user.User, error) {
 	return s.starRepository.GetStargazers(ctx, flt, assetID)
 }
+
 func (s *Service) Stars(ctx context.Context, userID, assetID string) (string, error) {
 	return s.starRepository.Create(ctx, userID, assetID)
 }
+
 func (s *Service) Unstars(ctx context.Context, userID, assetID string) error {
 	return s.starRepository.Delete(ctx, userID, assetID)
 }

--- a/core/star/star.go
+++ b/core/star/star.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Repository interface {
-	Create(ctx context.Context, userID string, assetID string) (string, error)
+	Create(ctx context.Context, userID, assetID string) (string, error)
 	GetStargazers(ctx context.Context, flt Filter, assetID string) ([]user.User, error)
 	GetAllAssetsByUserID(ctx context.Context, flt Filter, userID string) ([]asset.Asset, error)
-	GetAssetByUserID(ctx context.Context, userID string, assetID string) (asset.Asset, error)
-	Delete(ctx context.Context, userID string, assetID string) error
+	GetAssetByUserID(ctx context.Context, userID, assetID string) (asset.Asset, error)
+	Delete(ctx context.Context, userID, assetID string) error
 }

--- a/core/tag/service_test.go
+++ b/core/tag/service_test.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/golang-module/carbon/v2"
 	"github.com/google/uuid"
 	"github.com/goto/compass/core/tag"
 	"github.com/goto/compass/core/tag/mocks"
 	"github.com/goto/compass/core/tag/validator"
-
-	"github.com/golang-module/carbon/v2"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
@@ -60,7 +59,7 @@ func (s *ServiceTestSuite) TestValidate() {
 		actualError := tagService.Validate(&t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if template URN is empty", func() {
@@ -77,7 +76,7 @@ func (s *ServiceTestSuite) TestValidate() {
 		actualError := tagService.Validate(&t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if tag values are nil", func() {
@@ -94,7 +93,7 @@ func (s *ServiceTestSuite) TestValidate() {
 		actualError := tagService.Validate(&t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if tag values contains zero element", func() {
@@ -111,7 +110,7 @@ func (s *ServiceTestSuite) TestValidate() {
 		actualError := tagService.Validate(&t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if tag value field ID is zero", func() {
@@ -128,7 +127,7 @@ func (s *ServiceTestSuite) TestValidate() {
 		actualError := tagService.Validate(&t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if tag value field value is nil", func() {
@@ -145,7 +144,7 @@ func (s *ServiceTestSuite) TestValidate() {
 		actualError := tagService.Validate(&t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 }
 
@@ -166,7 +165,7 @@ func (s *ServiceTestSuite) TestCreate() {
 
 		actualError := s.tagService.CreateTag(ctx, &t)
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if error retrieving template", func() {
@@ -197,7 +196,7 @@ func (s *ServiceTestSuite) TestCreate() {
 		actualError := s.tagService.CreateTag(ctx, &t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if required field is not passed", func() {
@@ -218,8 +217,7 @@ func (s *ServiceTestSuite) TestCreate() {
 		actualError := s.tagService.CreateTag(ctx, &t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
-
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if passed value is not parsable", func() {
@@ -239,7 +237,7 @@ func (s *ServiceTestSuite) TestCreate() {
 		actualError := s.tagService.CreateTag(ctx, &t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return repository error if repository met error", func() {
@@ -303,7 +301,7 @@ func (s *ServiceTestSuite) TestFindByAssetAndTemplate() {
 
 	s.Run("should return nil and error if tag is not found", func() {
 		s.Setup()
-		var assetID = uuid.NewString()
+		assetID := uuid.NewString()
 		template := s.buildTemplate()
 		s.templateRepo.EXPECT().Read(mock.Anything, template.URN).Return([]tag.Template{template}, nil)
 		s.repository.EXPECT().Read(mock.Anything, tag.Tag{
@@ -355,7 +353,7 @@ func (s *ServiceTestSuite) TestUpdate() {
 		actualError := s.tagService.UpdateTag(ctx, &t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if error retrieving template", func() {
@@ -408,7 +406,7 @@ func (s *ServiceTestSuite) TestUpdate() {
 		actualError := s.tagService.UpdateTag(ctx, &t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if passed value is not parsable", func() {
@@ -432,7 +430,7 @@ func (s *ServiceTestSuite) TestUpdate() {
 		actualError := s.tagService.UpdateTag(ctx, &t)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return repository error if repository met error", func() {

--- a/core/tag/tag_template_service_test.go
+++ b/core/tag/tag_template_service_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/goto/compass/core/tag"
 	"github.com/goto/compass/core/tag/mocks"
 	"github.com/goto/compass/core/tag/validator"
-
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
@@ -55,7 +54,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if display name is empty", func() {
@@ -72,7 +71,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if description is empty", func() {
@@ -89,7 +88,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if fields is nil", func() {
@@ -106,7 +105,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if fields is empty", func() {
@@ -123,7 +122,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if fields urn is empty", func() {
@@ -140,7 +139,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if fields display name is empty", func() {
@@ -157,7 +156,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if fields description is empty", func() {
@@ -174,7 +173,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if fields data type is invalid", func() {
@@ -191,7 +190,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if fields data type enumerated but options nil", func() {
@@ -208,7 +207,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if fields data type enumerated but options empty", func() {
@@ -225,7 +224,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if fields data type enumerated but options contains empty", func() {
@@ -244,7 +243,7 @@ func (s *TemplateServiceTestSuite) TestValidate() {
 		actualError := service.Validate(template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return nil if fields data type not enumerated and options empty", func() {
@@ -283,7 +282,7 @@ func (s *TemplateServiceTestSuite) TestCreate() {
 		actualError := s.service.CreateTemplate(ctx, &template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if error encountered when checking for duplication", func() {
@@ -306,10 +305,7 @@ func (s *TemplateServiceTestSuite) TestCreate() {
 
 	s.Run("should return error if found error during create", func() {
 		s.Setup()
-		now := time.Now()
 		originalDomainTemplate := s.buildTemplate()
-		referenceDomainTemplate := s.buildTemplate()
-		referenceDomainTemplate.CreatedAt = now
 
 		s.repository.EXPECT().Read(ctx, originalDomainTemplate.URN).Return([]tag.Template{}, nil)
 		s.repository.EXPECT().Create(ctx, &originalDomainTemplate).Return(errors.New("unexpected error"))
@@ -410,7 +406,7 @@ func (s *TemplateServiceTestSuite) TestUpdate() {
 		actualError := s.service.UpdateTemplate(ctx, template.URN, &template)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if encountered unexpected error during read for existence", func() {
@@ -443,7 +439,7 @@ func (s *TemplateServiceTestSuite) TestUpdate() {
 		actualError := s.service.UpdateTemplate(ctx, newTemplate.URN, &newTemplate)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if trying to update field urn that already exist", func() {
@@ -466,7 +462,7 @@ func (s *TemplateServiceTestSuite) TestUpdate() {
 		actualError := s.service.UpdateTemplate(ctx, template.URN, &newTemplate)
 
 		s.EqualError(actualError, expectedErrorMsg)
-		s.EqualValues(expectedFieldError, actualError.(tag.ValidationError))
+		s.EqualValues(expectedFieldError, actualError)
 	})
 
 	s.Run("should return error if found error during update", func() {
@@ -501,7 +497,7 @@ func (s *TemplateServiceTestSuite) TestFind() {
 
 	s.Run("should return empty and error if found unexpected error", func() {
 		s.Setup()
-		var urn = "sample-urn"
+		urn := "sample-urn"
 		s.repository.EXPECT().Read(ctx, urn).Return(nil, errors.New("unexpected error"))
 
 		_, err := s.service.GetTemplate(ctx, urn)
@@ -510,7 +506,7 @@ func (s *TemplateServiceTestSuite) TestFind() {
 
 	s.Run("should return not found error if template is not found", func() {
 		s.Setup()
-		var urn = "sample-urn"
+		urn := "sample-urn"
 		s.repository.EXPECT().Read(ctx, urn).Return([]tag.Template{}, nil)
 
 		_, err := s.service.GetTemplate(ctx, urn)
@@ -520,7 +516,7 @@ func (s *TemplateServiceTestSuite) TestFind() {
 
 	s.Run("should return domain template and nil if record is found", func() {
 		s.Setup()
-		var urn = "sample-urn"
+		urn := "sample-urn"
 		template := s.buildTemplate()
 		s.repository.EXPECT().Read(ctx, urn).Return([]tag.Template{template}, nil)
 
@@ -538,7 +534,7 @@ func (s *TemplateServiceTestSuite) TestDelete() {
 
 	s.Run("should return error if encountered unexpected error during delete", func() {
 		s.Setup()
-		var urn = "sample-urn"
+		urn := "sample-urn"
 		s.repository.EXPECT().Delete(ctx, mock.Anything).Return(errors.New("unexpected error"))
 
 		actualError := s.service.DeleteTemplate(ctx, urn)
@@ -549,7 +545,7 @@ func (s *TemplateServiceTestSuite) TestDelete() {
 
 	s.Run("should return delete result from repository", func() {
 		s.Setup()
-		var urn = "sample-urn"
+		urn := "sample-urn"
 		s.repository.EXPECT().Delete(ctx, mock.Anything).Return(nil).Once()
 		s.repository.EXPECT().Delete(ctx, mock.Anything).Return(errors.New("unexpected error")).Once()
 

--- a/core/tag/utils.go
+++ b/core/tag/utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/goto/compass/core/tag/validator"
 )
 
-func buildFieldError(key string, message string) error {
+func buildFieldError(key, message string) error {
 	return ValidationError{
 		validator.FieldError{
 			key: message,
@@ -18,7 +18,7 @@ func buildFieldError(key string, message string) error {
 }
 
 func ParseTagValue(templateURN string, fieldID uint,
-	dataType string, tagValue string, options []string) (interface{}, error,
+	dataType, tagValue string, options []string) (interface{}, error,
 ) {
 	if tagValue == "" {
 		return nil, nil

--- a/core/user/context.go
+++ b/core/user/context.go
@@ -6,11 +6,9 @@ import (
 
 type contextKeyType struct{}
 
-var (
-	// userContextKey is the key used for user.FromContext and
-	// user.NewContext.
-	userContextKey = contextKeyType(struct{}{})
-)
+// userContextKey is the key used for user.FromContext and
+// user.NewContext.
+var userContextKey = contextKeyType(struct{}{})
 
 // NewContext returns a new context.Context that carries the provided
 // user ID.

--- a/core/user/errors.go
+++ b/core/user/errors.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 )
 
-var (
-	ErrNoUserInformation = errors.New("no user information")
-)
+var ErrNoUserInformation = errors.New("no user information")
 
 type NotFoundError struct {
 	UUID  string

--- a/core/user/errors_test.go
+++ b/core/user/errors_test.go
@@ -13,7 +13,7 @@ func TestErrors(t *testing.T) {
 		ExpectedString string
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:    "not found error return correct error string",
 			Err:            user.NotFoundError{UUID: "uuid", Email: "email"},

--- a/core/user/service_test.go
+++ b/core/user/service_test.go
@@ -21,7 +21,7 @@ func TestValidateUser(t *testing.T) {
 		ExpectErr   error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: "should return no user error when uuid is empty and email is optional",
 			UUID:        "",

--- a/core/user/user_test.go
+++ b/core/user/user_test.go
@@ -13,7 +13,7 @@ func TestValidate(t *testing.T) {
 		ExpectError error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:       "should return error no user information if user is nil",
 			User:        nil,
@@ -32,7 +32,6 @@ func TestValidate(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.Title, func(t *testing.T) {
-
 			err := testCase.User.Validate()
 			assert.Equal(t, testCase.ExpectError, err)
 		})

--- a/core/validator/validator.go
+++ b/core/validator/validator.go
@@ -13,15 +13,15 @@ import (
 var validate *validator.Validate
 
 func newValidator() *validator.Validate {
-	validate := validator.New()
-	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
+	v := validator.New()
+	v.RegisterTagNameFunc(func(fld reflect.StructField) string {
 		name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
 		if name == "-" {
 			return ""
 		}
 		return name
 	})
-	return validate
+	return v
 }
 
 func ValidateStruct(f interface{}) error {
@@ -43,28 +43,32 @@ func getValidator() *validator.Validate {
 }
 
 func checkError(err error) error {
-	if err != nil {
-		errs := err.(validator.ValidationErrors)
-		errStrs := []string{}
-		for _, e := range errs {
-			if e.Tag() == "oneof" {
-				errStrValue := fmt.Sprintf("error value \"%s\"", e.Value())
-				if e.Field() != "" {
-					errStrValue = errStrValue + fmt.Sprintf(" for key \"%s\"", e.Field())
-				}
-				errStrValue = errStrValue + fmt.Sprintf(" not recognized, only support \"%s\"", e.Param())
-				errStrs = append(errStrs, errStrValue)
-				continue
-			}
+	if err == nil {
+		return nil
+	}
 
-			if e.Tag() == "gte" {
-				errStrs = append(errStrs, fmt.Sprintf("%s cannot be less than %s", e.Field(), e.Param()))
-				continue
-			}
+	var errs validator.ValidationErrors
+	if !errors.As(err, &errs) {
+		return err
+	}
 
+	var errStrs []string
+	for _, e := range errs {
+		switch e.Tag() {
+		case "oneof":
+			errStr := fmt.Sprintf("error value %q", e.Value())
+			if e.Field() != "" {
+				errStr += fmt.Sprintf(" for key %q", e.Field())
+			}
+			errStr += fmt.Sprintf(" not recognized, only support %q", e.Param())
+			errStrs = append(errStrs, errStr)
+
+		case "gte":
+			errStrs = append(errStrs, fmt.Sprintf("%s cannot be less than %s", e.Field(), e.Param()))
+
+		default:
 			errStrs = append(errStrs, e.Error())
 		}
-		return errors.New(strings.Join(errStrs, " and "))
 	}
-	return nil
+	return errors.New(strings.Join(errStrs, " and "))
 }

--- a/internal/server/health/health_test.go
+++ b/internal/server/health/health_test.go
@@ -17,7 +17,7 @@ func TestHealthCheck(t *testing.T) {
 		PostCheck    func(resp *grpc_health_v1.HealthCheckResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  `should return OK if server is serving`,
 			ExpectStatus: codes.OK,
@@ -54,7 +54,7 @@ func TestHealthWatch(t *testing.T) {
 		PostCheck    func(wc grpc_health_v1.Health_WatchClient) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  `should return unimplemented`,
 			ExpectStatus: codes.Unimplemented,
@@ -63,7 +63,6 @@ func TestHealthWatch(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Description, func(t *testing.T) {
-
 			healthHandler := NewHandler()
 
 			err := healthHandler.Watch(tc.Request, nil)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,7 +73,6 @@ func Serve(
 	tagTemplateService handlersv1beta1.TagTemplateService,
 	userService handlersv1beta1.UserService,
 ) error {
-
 	v1beta1Handler := handlersv1beta1.NewAPIServer(
 		logger,
 		assetService,

--- a/internal/server/v1beta1/asset_test.go
+++ b/internal/server/v1beta1/asset_test.go
@@ -40,7 +40,7 @@ func TestGetAllAssets(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetAllAssetsResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  `should return internal server error if fetching fails`,
 			ExpectStatus: codes.Internal,
@@ -230,7 +230,7 @@ func TestGetAssetByID(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetAssetByIDResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  `should return invalid argument if asset id is not uuid`,
 			ExpectStatus: codes.InvalidArgument,
@@ -372,7 +372,7 @@ func TestUpsertAsset(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.UpsertAssetResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "empty payload will return invalid argument",
 			Request:      &compassv1beta1.UpsertAssetRequest{},
@@ -578,7 +578,7 @@ func TestUpsertPatchAsset(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.UpsertPatchAssetResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "empty payload will return invalid argument",
 			Request:      &compassv1beta1.UpsertPatchAssetRequest{},
@@ -694,7 +694,6 @@ func TestUpsertPatchAsset(t *testing.T) {
 					return fmt.Errorf("expected response to be %+v, was %+v", expected, resp)
 				}
 				return nil
-
 			},
 		},
 		{
@@ -740,7 +739,6 @@ func TestUpsertPatchAsset(t *testing.T) {
 					return fmt.Errorf("expected response to be %+v, was %+v", expected, resp)
 				}
 				return nil
-
 			},
 		},
 		{
@@ -787,7 +785,6 @@ func TestUpsertPatchAsset(t *testing.T) {
 					return fmt.Errorf("expected response to be %+v, was %+v", expected, resp)
 				}
 				return nil
-
 			},
 		},
 	}
@@ -836,7 +833,7 @@ func TestDeleteAsset(t *testing.T) {
 		Setup        func(ctx context.Context, as *mocks.AssetService, astID string)
 	}
 
-	var testCases = []TestCase{
+	testCases := []TestCase{
 		{
 			Description:  "should return invalid argument when asset id is not uuid",
 			AssetID:      "not-uuid",
@@ -898,12 +895,10 @@ func TestDeleteAsset(t *testing.T) {
 }
 
 func TestGetAssetStargazers(t *testing.T) {
-
 	var (
 		offset         = 10
 		size           = 20
 		defaultStarCfg = star.Filter{Offset: offset, Size: size}
-		assetID        = uuid.NewString()
 		userID         = uuid.NewString()
 		userUUID       = uuid.NewString()
 	)
@@ -916,7 +911,7 @@ func TestGetAssetStargazers(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetAssetStargazersResponse) error
 	}
 
-	var testCases = []TestCase{
+	testCases := []TestCase{
 		{
 			Description:  "should return internal server error if failed to fetch star repository",
 			ExpectStatus: codes.Internal,
@@ -987,9 +982,7 @@ func TestGetAssetStargazers(t *testing.T) {
 }
 
 func TestGetAssetVersionHistory(t *testing.T) {
-
 	var (
-		assetID  = uuid.NewString()
 		userID   = uuid.NewString()
 		userUUID = uuid.NewString()
 	)
@@ -1002,7 +995,7 @@ func TestGetAssetVersionHistory(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetAssetVersionHistoryResponse) error
 	}
 
-	var testCases = []TestCase{
+	testCases := []TestCase{
 		{
 			Description:  `should return invalid argument if asset id is not uuid`,
 			ExpectStatus: codes.InvalidArgument,
@@ -1102,11 +1095,9 @@ func TestGetAssetVersionHistory(t *testing.T) {
 }
 
 func TestGetAssetByVersion(t *testing.T) {
-
 	var (
 		userID   = uuid.NewString()
 		userUUID = uuid.NewString()
-		assetID  = uuid.NewString()
 		version  = "0.2"
 		ast      = asset.Asset{
 			ID:      assetID,
@@ -1123,7 +1114,7 @@ func TestGetAssetByVersion(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetAssetByVersionResponse) error
 	}
 
-	var testCases = []TestCase{
+	testCases := []TestCase{
 		{
 			Description: `should return invalid argument if asset id is not uuid`,
 			Request: &compassv1beta1.GetAssetByVersionRequest{
@@ -1232,7 +1223,7 @@ func TestCreateAssetProbe(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.CreateAssetProbeResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  `should return error if id is not a valid UUID`,
 			ExpectStatus: codes.InvalidArgument,
@@ -1403,7 +1394,7 @@ func TestAssetToProto(t *testing.T) {
 		ExpectProto *compassv1beta1.Asset
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:       "should return nil data pb, label pb, empty owners pb, nil changelog pb, no timestamp pb if data is empty",
 			Asset:       asset.Asset{ID: "id1", URN: "urn1"},
@@ -1441,7 +1432,6 @@ func TestAssetToProto(t *testing.T) {
 				},
 				Changelog: []*compassv1beta1.Change{
 					{
-
 						From: structpb.NewStringValue("1"),
 						To:   structpb.NewStringValue("2"),
 						Path: []string{"path1/path2"},
@@ -1454,7 +1444,6 @@ func TestAssetToProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got, err := assetToProto(tc.Asset, true)
 			if err != nil {
 				t.Error(err)
@@ -1481,7 +1470,7 @@ func TestAssetFromProto(t *testing.T) {
 		ExpectAsset asset.Asset
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:       "should return empty labels, data, and owners if all pb empty",
 			AssetPB:     &compassv1beta1.Asset{Id: "id1"},
@@ -1507,7 +1496,6 @@ func TestAssetFromProto(t *testing.T) {
 				},
 				Changelog: []*compassv1beta1.Change{
 					{
-
 						From: structpb.NewStringValue("1"),
 						To:   structpb.NewStringValue("2"),
 						Path: []string{"path1/path2"},
@@ -1548,7 +1536,6 @@ func TestAssetFromProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := assetFromProto(tc.AssetPB)
 			if reflect.DeepEqual(got, tc.ExpectAsset) == false {
 				t.Errorf("expected returned asset to be %+v, was %+v", tc.ExpectAsset, got)

--- a/internal/server/v1beta1/comment.go
+++ b/internal/server/v1beta1/comment.go
@@ -183,7 +183,6 @@ func (server *APIServer) DeleteComment(ctx context.Context, req *compassv1beta1.
 }
 
 func (server *APIServer) buildGetAllDiscussionsFilter(req *compassv1beta1.GetAllDiscussionsRequest) (discussion.Filter, error) {
-
 	fl := discussion.Filter{
 		Type:          req.GetType(),
 		State:         req.GetState(),
@@ -220,7 +219,6 @@ func (server *APIServer) buildGetAllDiscussionsFilter(req *compassv1beta1.GetAll
 }
 
 func (server *APIServer) buildGetAllCommentsFilter(req *compassv1beta1.GetAllCommentsRequest) (discussion.Filter, error) {
-
 	fl := discussion.Filter{
 		SortBy:        req.GetSort(),
 		SortDirection: req.GetDirection(),
@@ -240,7 +238,6 @@ func (server *APIServer) buildGetAllCommentsFilter(req *compassv1beta1.GetAllCom
 
 // commentToProto transforms struct to proto
 func commentToProto(c discussion.Comment) *compassv1beta1.Comment {
-
 	var createdAtPB *timestamppb.Timestamp
 	if !c.CreatedAt.IsZero() {
 		createdAtPB = timestamppb.New(c.CreatedAt)

--- a/internal/server/v1beta1/comment_test.go
+++ b/internal/server/v1beta1/comment_test.go
@@ -41,7 +41,7 @@ func TestCreateComment(t *testing.T) {
 		Setup        func(context.Context, *mocks.DiscussionService)
 	}
 
-	var testCases = []TestCase{
+	testCases := []TestCase{
 		{
 			Description: "should return invalid request if empty request",
 			Request: &compassv1beta1.CreateCommentRequest{
@@ -134,7 +134,7 @@ func TestGetAllComments(t *testing.T) {
 		Setup        func(context.Context, *mocks.DiscussionService)
 		PostCheck    func(resp *compassv1beta1.GetAllCommentsResponse) error
 	}
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return invalid argument if discussion_id is not integer`,
 			Request: &compassv1beta1.GetAllCommentsRequest{
@@ -264,7 +264,7 @@ func TestGetComment(t *testing.T) {
 		Setup        func(context.Context, *mocks.DiscussionService)
 		PostCheck    func(resp *compassv1beta1.GetCommentResponse) error
 	}
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  `should return internal server error if fetching fails`,
 			ExpectStatus: codes.Internal,
@@ -384,7 +384,7 @@ func TestUpdateComment(t *testing.T) {
 		discussionID = "123"
 		commentID    = "11"
 	)
-	var validRequest = &compassv1beta1.UpdateCommentRequest{
+	validRequest := &compassv1beta1.UpdateCommentRequest{
 		Id:           commentID,
 		DiscussionId: discussionID,
 		Body:         "lorem ipsum",
@@ -634,7 +634,7 @@ func TestCommentToProto(t *testing.T) {
 		ExpectProto *compassv1beta1.Comment
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:       "should return no timestamp pb if timestamp is zero",
 			Comment:     discussion.Comment{ID: "id1"},
@@ -648,7 +648,6 @@ func TestCommentToProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := commentToProto(tc.Comment)
 			if diff := cmp.Diff(got, tc.ExpectProto, protocmp.Transform()); diff != "" {
 				t.Errorf("expected response to be %+v, was %+v", tc.ExpectProto, got)
@@ -665,7 +664,7 @@ func TestCommentFromProto(t *testing.T) {
 		Expect discussion.Comment
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:  "should return non empty time.Time, owner, and updated by if pb is not empty or zero",
 			PB:     &compassv1beta1.Comment{Id: "id1", Owner: &compassv1beta1.User{Id: "uid1"}, UpdatedBy: &compassv1beta1.User{Id: "uid1"}, CreatedAt: timestamppb.New(timeDummy), UpdatedAt: timestamppb.New(timeDummy)},
@@ -679,7 +678,6 @@ func TestCommentFromProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := commentFromProto(tc.PB)
 			if reflect.DeepEqual(got, tc.Expect) == false {
 				t.Errorf("expected returned asset to be %+v, was %+v", tc.Expect, got)

--- a/internal/server/v1beta1/discussion.go
+++ b/internal/server/v1beta1/discussion.go
@@ -22,9 +22,9 @@ type DiscussionService interface {
 	PatchDiscussion(ctx context.Context, discussion *discussion.Discussion) error
 	GetComments(ctx context.Context, discussionID string, filter discussion.Filter) ([]discussion.Comment, error)
 	CreateComment(ctx context.Context, cmt *discussion.Comment) (string, error)
-	GetComment(ctx context.Context, commentID string, discussionID string) (discussion.Comment, error)
+	GetComment(ctx context.Context, commentID, discussionID string) (discussion.Comment, error)
 	UpdateComment(ctx context.Context, cmt *discussion.Comment) error
-	DeleteComment(ctx context.Context, commentID string, discussionID string) error
+	DeleteComment(ctx context.Context, commentID, discussionID string) error
 }
 
 // GetAll returns all discussion based on filter in query params
@@ -185,7 +185,6 @@ func (server *APIServer) validateIDInteger(id string) error {
 
 // discussionToProto transforms struct to proto
 func discussionToProto(d discussion.Discussion) *compassv1beta1.Discussion {
-
 	var createdAtPB *timestamppb.Timestamp
 	if !d.CreatedAt.IsZero() {
 		createdAtPB = timestamppb.New(d.CreatedAt)

--- a/internal/server/v1beta1/discussion_test.go
+++ b/internal/server/v1beta1/discussion_test.go
@@ -36,7 +36,7 @@ func TestGetAllDiscussions(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetAllDiscussionsResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return internal server error if fetching fails`,
 			Setup: func(ctx context.Context, ds *mocks.DiscussionService) {
@@ -147,7 +147,7 @@ func TestCreateDiscussion(t *testing.T) {
 		userID   = uuid.NewString()
 		userUUID = uuid.NewString()
 	)
-	var validRequest = &compassv1beta1.CreateDiscussionRequest{
+	validRequest := &compassv1beta1.CreateDiscussionRequest{
 		Title: "Lorem Ipsum",
 		Body:  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
 		Type:  discussion.TypeQAndA.String(),
@@ -160,7 +160,7 @@ func TestCreateDiscussion(t *testing.T) {
 		ExpectStatus codes.Code
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "should return invalid argument if empty object",
 			Request:      &compassv1beta1.CreateDiscussionRequest{},
@@ -279,7 +279,7 @@ func TestGetDiscussion(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetDiscussionResponse) error
 	}
 
-	var testCases = []TestCase{
+	testCases := []TestCase{
 		{
 			Description:  `should return internal server error if fetching fails`,
 			ExpectStatus: codes.Internal,
@@ -377,7 +377,7 @@ func TestPatchDiscussion(t *testing.T) {
 		discussionID = "123"
 	)
 
-	var validRequest = &compassv1beta1.PatchDiscussionRequest{Id: discussionID, Title: "lorem ipsum"}
+	validRequest := &compassv1beta1.PatchDiscussionRequest{Id: discussionID, Title: "lorem ipsum"}
 
 	type TestCase struct {
 		Description  string
@@ -510,7 +510,7 @@ func TestDiscussionToProto(t *testing.T) {
 		ExpectProto *compassv1beta1.Discussion
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:       "should return no timestamp pb if timestamp is zero",
 			Discussion:  discussion.Discussion{ID: "id1"},
@@ -524,7 +524,6 @@ func TestDiscussionToProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := discussionToProto(tc.Discussion)
 			if diff := cmp.Diff(got, tc.ExpectProto, protocmp.Transform()); diff != "" {
 				t.Errorf("expected response to be %+v, was %+v", tc.ExpectProto, got)
@@ -541,7 +540,7 @@ func TestDiscussionFromProto(t *testing.T) {
 		ExpectDiscussion discussion.Discussion
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:            "should return non empty time.Time and owner if pb is not empty or zero",
 			DiscussionPB:     &compassv1beta1.Discussion{Id: "id1", Owner: &compassv1beta1.User{Id: "uid1"}, CreatedAt: timestamppb.New(timeDummy), UpdatedAt: timestamppb.New(timeDummy)},
@@ -555,7 +554,6 @@ func TestDiscussionFromProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := discussionFromProto(tc.DiscussionPB)
 			if reflect.DeepEqual(got, tc.ExpectDiscussion) == false {
 				t.Errorf("expected returned asset to be %+v, was %+v", tc.ExpectDiscussion, got)

--- a/internal/server/v1beta1/lineage_test.go
+++ b/internal/server/v1beta1/lineage_test.go
@@ -106,6 +106,5 @@ func TestGetLineageGraph(t *testing.T) {
 				t.Errorf("expected: %+v\ngot: %+v\ndiff: %s\n", expected, got, diff)
 			}
 		})
-
 	})
 }

--- a/internal/server/v1beta1/search.go
+++ b/internal/server/v1beta1/search.go
@@ -128,7 +128,7 @@ func (server *APIServer) SuggestAssets(ctx context.Context, req *compassv1beta1.
 }
 
 func filterConfigFromValues(fltMap map[string]string) map[string][]string {
-	var filter = make(map[string][]string)
+	filter := make(map[string][]string)
 	for key, value := range fltMap {
 		var filterValues []string
 		filterValues = append(filterValues, strings.Split(value, ",")...)

--- a/internal/server/v1beta1/search_test.go
+++ b/internal/server/v1beta1/search_test.go
@@ -10,15 +10,14 @@ import (
 	"github.com/goto/compass/core/asset"
 	"github.com/goto/compass/core/user"
 	"github.com/goto/compass/internal/server/v1beta1/mocks"
+	"github.com/goto/compass/internal/testutils"
 	compassv1beta1 "github.com/goto/compass/proto/gotocompany/compass/v1beta1"
 	"github.com/goto/salt/log"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
-
-	"github.com/goto/compass/internal/testutils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSearch(t *testing.T) {
@@ -34,7 +33,7 @@ func TestSearch(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.SearchAssetsResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "should return invalid argument if 'text' parameter is empty or missing",
 			ExpectStatus: codes.InvalidArgument,
@@ -63,7 +62,6 @@ func TestSearch(t *testing.T) {
 				},
 			},
 			Setup: func(ctx context.Context, as *mocks.AssetService) {
-
 				cfg := asset.SearchConfig{
 					Text: "resource",
 					Filters: map[string][]string{
@@ -91,7 +89,6 @@ func TestSearch(t *testing.T) {
 				},
 			},
 			Setup: func(ctx context.Context, as *mocks.AssetService) {
-
 				cfg := asset.SearchConfig{
 					Text: "resource",
 					Filters: map[string][]string{
@@ -107,14 +104,14 @@ func TestSearch(t *testing.T) {
 
 				as.EXPECT().SearchAssets(ctx, cfg).Return([]asset.SearchResult{}, nil)
 			},
-		}, {
+		},
+		{
 			Description: "should parse offset",
 			Request: &compassv1beta1.SearchAssetsRequest{
 				Text:   "resource",
 				Offset: 10,
 			},
 			Setup: func(ctx context.Context, as *mocks.AssetService) {
-
 				cfg := asset.SearchConfig{
 					Text:    "resource",
 					Filters: make(map[string][]string),
@@ -131,7 +128,6 @@ func TestSearch(t *testing.T) {
 				Text: "test",
 			},
 			Setup: func(ctx context.Context, as *mocks.AssetService) {
-
 				cfg := asset.SearchConfig{
 					Text:    "test",
 					Filters: make(map[string][]string),
@@ -180,7 +176,6 @@ func TestSearch(t *testing.T) {
 				Size: 10,
 			},
 			Setup: func(ctx context.Context, as *mocks.AssetService) {
-
 				cfg := asset.SearchConfig{
 					Text:       "resource",
 					MaxResults: 10,
@@ -262,7 +257,7 @@ func TestSuggest(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.SuggestAssetsResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "should return invalid arguments if 'text' parameter is empty or missing",
 			ExpectStatus: codes.InvalidArgument,
@@ -287,7 +282,6 @@ func TestSuggest(t *testing.T) {
 				Text: "test",
 			},
 			Setup: func(ctx context.Context, as *mocks.AssetService) {
-
 				cfg := asset.SearchConfig{
 					Text: "test",
 				}
@@ -360,7 +354,7 @@ func TestGroupAssets(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GroupAssetsResponse)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "should return invalid argument if 'groupby' parameter is empty or missing",
 			ExpectStatus: codes.InvalidArgument,
@@ -436,21 +430,23 @@ func TestGroupAssets(t *testing.T) {
 				}
 				response := []asset.GroupResult{
 					{
-						Fields: []asset.GroupField{{
-							Name:  "resource",
-							Value: "kafka",
-						},
-						},
-						Assets: []asset.Asset{{
-							Type:        "test",
-							ID:          "test-resource",
-							Description: "some description",
-							Service:     "test-service",
-							Labels: map[string]string{
-								"entity":    "gotocompany",
-								"landscape": "id",
+						Fields: []asset.GroupField{
+							{
+								Name:  "resource",
+								Value: "kafka",
 							},
 						},
+						Assets: []asset.Asset{
+							{
+								Type:        "test",
+								ID:          "test-resource",
+								Description: "some description",
+								Service:     "test-service",
+								Labels: map[string]string{
+									"entity":    "gotocompany",
+									"landscape": "id",
+								},
+							},
 						},
 					},
 				}

--- a/internal/server/v1beta1/server.go
+++ b/internal/server/v1beta1/server.go
@@ -26,9 +26,7 @@ type APIServer struct {
 	statsDReporter     StatsDClient
 }
 
-var (
-	errMissingUserInfo = errors.New("missing user information")
-)
+var errMissingUserInfo = errors.New("missing user information")
 
 func NewAPIServer(
 	logger log.Logger,

--- a/internal/server/v1beta1/tag.go
+++ b/internal/server/v1beta1/tag.go
@@ -103,7 +103,6 @@ func (server *APIServer) CreateTagAsset(ctx context.Context, req *compassv1beta1
 	err = server.tagService.CreateTag(ctx, &tagDomain)
 	if errors.As(err, new(tag.DuplicateError)) {
 		return nil, status.Error(codes.AlreadyExists, err.Error())
-
 	}
 	if errors.As(err, new(tag.TemplateNotFoundError)) {
 		return nil, status.Error(codes.NotFound, err.Error())
@@ -113,7 +112,6 @@ func (server *APIServer) CreateTagAsset(ctx context.Context, req *compassv1beta1
 	}
 	if err != nil {
 		return nil, internalServerError(server.logger, fmt.Sprintf("error creating tag: %s", err.Error()))
-
 	}
 
 	tagPB, err := tagToProto(tagDomain)

--- a/internal/server/v1beta1/tag_template_test.go
+++ b/internal/server/v1beta1/tag_template_test.go
@@ -84,7 +84,7 @@ func TestGetAllTagTemplates(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetAllTagTemplatesResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return internal server error if found unexpected error`,
 			Request: &compassv1beta1.GetAllTagTemplatesRequest{
@@ -116,7 +116,8 @@ func TestGetAllTagTemplates(t *testing.T) {
 				}
 				return nil
 			},
-		}, {
+		},
+		{
 			Description:  `should return all templates if no urn query params`,
 			Request:      &compassv1beta1.GetAllTagTemplatesRequest{},
 			ExpectStatus: codes.OK,
@@ -191,7 +192,7 @@ func TestCreateTagTemplate(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.CreateTagTemplateResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  `should return already exist if duplicate template`,
 			Request:      validRequest,
@@ -278,7 +279,7 @@ func TestGetTagTemplate(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetTagTemplateResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  `should return not found if template is not found`,
 			Request:      validRequest,
@@ -359,7 +360,7 @@ func TestUpdateTagTemplate(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.UpdateTagTemplateResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  `should return not found if template is not found`,
 			Request:      validRequest,
@@ -456,7 +457,7 @@ func TestDeleteTagTemplate(t *testing.T) {
 		Setup        func(context.Context, *mocks.TagService, *mocks.TagTemplateService)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  `should return not found if template is not found`,
 			Request:      validRequest,
@@ -511,7 +512,7 @@ func TestTemplateToProto(t *testing.T) {
 		ExpectProto *compassv1beta1.TagTemplate
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:       "should return no timestamp pb and empty template field pb if timestamp and template field are empty",
 			Template:    tag.Template{URN: "urn", DisplayName: "display-name", Description: "description"},
@@ -525,7 +526,6 @@ func TestTemplateToProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := tagTemplateToProto(tc.Template)
 			if diff := cmp.Diff(got, tc.ExpectProto, protocmp.Transform()); diff != "" {
 				t.Errorf("expected response to be %+v, was %+v", tc.ExpectProto, got)
@@ -542,7 +542,7 @@ func TestTagTemplateFromProto(t *testing.T) {
 		Expect tag.Template
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:  "should return non empty time.Time and field if timestamp pb and field pb are not empty or zero",
 			PB:     &compassv1beta1.TagTemplate{Urn: "urn", DisplayName: "display-name", Description: "description", Fields: []*compassv1beta1.TagTemplateField{{Id: 12, Urn: "urn1"}}, CreatedAt: timestamppb.New(timeDummy), UpdatedAt: timestamppb.New(timeDummy)},
@@ -556,7 +556,6 @@ func TestTagTemplateFromProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := tagTemplateFromProto(tc.PB)
 			if reflect.DeepEqual(got, tc.Expect) == false {
 				t.Errorf("expected returned asset to be %+v, was %+v", tc.Expect, got)
@@ -573,7 +572,7 @@ func TestTemplateFieldToProto(t *testing.T) {
 		ExpectProto *compassv1beta1.TagTemplateField
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:       "should return no timestamp pb if timestamp is empty",
 			Field:       tag.Field{ID: 123, URN: "urn"},
@@ -587,7 +586,6 @@ func TestTemplateFieldToProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := tagTemplateFieldToProto(tc.Field)
 			if diff := cmp.Diff(got, tc.ExpectProto, protocmp.Transform()); diff != "" {
 				t.Errorf("expected response to be %+v, was %+v", tc.ExpectProto, got)
@@ -604,7 +602,7 @@ func TestTagTemplateFieldFromProto(t *testing.T) {
 		Expect tag.Field
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:  "should return non empty time.Time if timestamp pb is not empty",
 			PB:     &compassv1beta1.TagTemplateField{Id: 123, Urn: "urn", CreatedAt: timestamppb.New(timeDummy), UpdatedAt: timestamppb.New(timeDummy)},
@@ -618,7 +616,6 @@ func TestTagTemplateFieldFromProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := tagTemplateFieldFromProto(tc.PB)
 			if reflect.DeepEqual(got, tc.Expect) == false {
 				t.Errorf("expected returned asset to be %+v, was %+v", tc.Expect, got)

--- a/internal/server/v1beta1/tag_test.go
+++ b/internal/server/v1beta1/tag_test.go
@@ -22,34 +22,36 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var assetID = uuid.NewString()
-var sampleTag = tag.Tag{
-	AssetID:             assetID,
-	TemplateURN:         "governance_policy",
-	TemplateDisplayName: "Governance Policy",
-	TemplateDescription: "Template that is mandatory to be used.",
-	TagValues: []tag.TagValue{
-		{
-			FieldID:          1,
-			FieldValue:       "Public",
-			FieldURN:         "classification",
-			FieldDisplayName: "classification",
-			FieldDescription: "The classification of this asset",
-			FieldDataType:    "enumerated",
-			FieldRequired:    true,
-			FieldOptions:     []string{"Public", "Restricted"},
+var (
+	assetID   = uuid.NewString()
+	sampleTag = tag.Tag{
+		AssetID:             assetID,
+		TemplateURN:         "governance_policy",
+		TemplateDisplayName: "Governance Policy",
+		TemplateDescription: "Template that is mandatory to be used.",
+		TagValues: []tag.TagValue{
+			{
+				FieldID:          1,
+				FieldValue:       "Public",
+				FieldURN:         "classification",
+				FieldDisplayName: "classification",
+				FieldDescription: "The classification of this asset",
+				FieldDataType:    "enumerated",
+				FieldRequired:    true,
+				FieldOptions:     []string{"Public", "Restricted"},
+			},
+			{
+				FieldID:          2,
+				FieldValue:       true,
+				FieldURN:         "is_encrypted",
+				FieldDisplayName: "Is Encrypted?",
+				FieldDescription: "Specify whether this asset is encrypted or not.",
+				FieldDataType:    "boolean",
+				FieldRequired:    true,
+			},
 		},
-		{
-			FieldID:          2,
-			FieldValue:       true,
-			FieldURN:         "is_encrypted",
-			FieldDisplayName: "Is Encrypted?",
-			FieldDescription: "Specify whether this asset is encrypted or not.",
-			FieldDataType:    "boolean",
-			FieldRequired:    true,
-		},
-	},
-}
+	}
+)
 
 var sampleTagPB = &compassv1beta1.Tag{
 	AssetId:             assetID,
@@ -92,7 +94,7 @@ func TestGetTagByAssetAndTemplate(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetTagByAssetAndTemplateResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return invalid argument if asset id is empty`,
 			Request: &compassv1beta1.GetTagByAssetAndTemplateRequest{
@@ -236,7 +238,7 @@ func TestCreateTagAsset(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.CreateTagAssetResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return invalid argument if asset id is empty`,
 			Request: &compassv1beta1.CreateTagAssetRequest{
@@ -368,7 +370,7 @@ func TestUpdateTagAsset(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.UpdateTagAssetResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return invalid argument if asset id is empty`,
 			Request: &compassv1beta1.UpdateTagAssetRequest{
@@ -476,7 +478,7 @@ func TestDeleteTagAsset(t *testing.T) {
 		Setup        func(context.Context, *mocks.TagService, *mocks.TagTemplateService)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return invalid argument if asset id is empty`,
 			Request: &compassv1beta1.DeleteTagAssetRequest{
@@ -571,7 +573,7 @@ func TestGetAllTagsByAsset(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetAllTagsByAssetResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description: `should return invalid argument if asset id is empty`,
 			Request: &compassv1beta1.GetAllTagsByAssetRequest{
@@ -647,7 +649,7 @@ func TestTagToProto(t *testing.T) {
 		ExpectProto *compassv1beta1.Tag
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:       "should return empty field value pb if tag values is empty",
 			Tag:         tag.Tag{AssetID: "1111-2222-3333-4444"},
@@ -661,7 +663,6 @@ func TestTagToProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got, err := tagToProto(tc.Tag)
 			if err != nil {
 				t.Fatal(err)
@@ -680,7 +681,7 @@ func TestTagFromProto(t *testing.T) {
 		Expect tag.Tag
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:  "should return non empty tag values if tag values pb are not empty",
 			PB:     &compassv1beta1.Tag{AssetId: "1111-2222-3333-4444", TagValues: []*compassv1beta1.TagValue{{FieldId: 123, FieldUrn: "urn"}}},
@@ -694,7 +695,6 @@ func TestTagFromProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := tagFromProto(tc.PB)
 			if reflect.DeepEqual(got, tc.Expect) == false {
 				t.Errorf("expected returned asset to be %+v, was %+v", tc.Expect, got)
@@ -711,7 +711,7 @@ func TestTagValueToProto(t *testing.T) {
 		ExpectProto *compassv1beta1.TagValue
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:       "should return no timestamp pb and empty field value pb if timestamp and field value are empty or zero",
 			TagValue:    tag.TagValue{FieldID: 123, FieldURN: "urn"},
@@ -725,7 +725,6 @@ func TestTagValueToProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got, err := tagValueToProto(tc.TagValue)
 			if err != nil {
 				t.Fatal(err)
@@ -745,7 +744,7 @@ func TestTagValueFromProto(t *testing.T) {
 		Expect tag.TagValue
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:  "should return non empty time.Time and field value if timestamp pb and field value pb are not empty or zero",
 			PB:     &compassv1beta1.TagValue{FieldId: 123, FieldUrn: "urn", FieldValue: structpb.NewStringValue("a value"), CreatedAt: timestamppb.New(timeDummy), UpdatedAt: timestamppb.New(timeDummy)},
@@ -759,7 +758,6 @@ func TestTagValueFromProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := tagValueFromProto(tc.PB)
 			if reflect.DeepEqual(got, tc.Expect) == false {
 				t.Errorf("expected returned asset to be %+v, was %+v", tc.Expect, got)

--- a/internal/server/v1beta1/type_test.go
+++ b/internal/server/v1beta1/type_test.go
@@ -30,7 +30,7 @@ func TestGetTypes(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetAllTypesResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "should return internal server error if failing to fetch types",
 			ExpectStatus: codes.Internal,

--- a/internal/server/v1beta1/user_test.go
+++ b/internal/server/v1beta1/user_test.go
@@ -37,7 +37,7 @@ func TestGetUserStarredAssets(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetUserStarredAssetsResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "should return internal server error if failed to fetch starred",
 			ExpectStatus: codes.Internal,
@@ -149,7 +149,7 @@ func TestGetMyStarredAssets(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetMyStarredAssetsResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "should return internal server error if failed to fetch starred",
 			ExpectStatus: codes.Internal,
@@ -261,7 +261,7 @@ func TestGetMyStarredAsset(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetMyStarredAssetResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "should return invalid argument if asset id is empty",
 			ExpectStatus: codes.InvalidArgument,
@@ -359,7 +359,7 @@ func TestStarAsset(t *testing.T) {
 		Setup        func(context.Context, *mocks.StarService)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "should return invalid argument if asset id in param is invalid",
 			ExpectStatus: codes.InvalidArgument,
@@ -445,7 +445,7 @@ func TestUnstarAsset(t *testing.T) {
 		Setup        func(context.Context, *mocks.StarService)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  "should return invalid argument if asset id in param is empty",
 			ExpectStatus: codes.InvalidArgument,
@@ -518,7 +518,7 @@ func TestGetMyDiscussions(t *testing.T) {
 		PostCheck    func(resp *compassv1beta1.GetMyDiscussionsResponse) error
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Description:  `should return internal server error if fetching fails`,
 			Request:      &compassv1beta1.GetMyDiscussionsRequest{},
@@ -561,7 +561,8 @@ func TestGetMyDiscussions(t *testing.T) {
 					DisjointAssigneeOwner: false,
 				}).Return([]discussion.Discussion{}, nil)
 			},
-		}, {
+		},
+		{
 			Description: `should search by assigned or created if filter is all`,
 			Request: &compassv1beta1.GetMyDiscussionsRequest{
 				Filter: "all",
@@ -670,7 +671,7 @@ func TestUserToProto(t *testing.T) {
 		ExpectProto *compassv1beta1.User
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:       "should return nil if UUID is empty",
 			User:        user.User{},
@@ -684,7 +685,6 @@ func TestUserToProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := userToProto(tc.User)
 			if diff := cmp.Diff(got, tc.ExpectProto, protocmp.Transform()); diff != "" {
 				t.Errorf("expected response to be %+v, was %+v", tc.ExpectProto, got)
@@ -701,7 +701,7 @@ func TestUserToFullProto(t *testing.T) {
 		ExpectProto *compassv1beta1.User
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:       "should return nil if UUID is empty",
 			User:        user.User{},
@@ -720,7 +720,6 @@ func TestUserToFullProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := userToFullProto(tc.User)
 			if diff := cmp.Diff(got, tc.ExpectProto, protocmp.Transform()); diff != "" {
 				t.Errorf("expected response to be %+v, was %+v", tc.ExpectProto, got)
@@ -737,7 +736,7 @@ func TestUserFromProto(t *testing.T) {
 		ExpectUser user.User
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			Title:      "should return non empty time.Time if timestamp pb is not zero",
 			UserPB:     &compassv1beta1.User{Uuid: "uuid1", Provider: "provider", CreatedAt: timestamppb.New(timeDummy), UpdatedAt: timestamppb.New(timeDummy)},
@@ -751,7 +750,6 @@ func TestUserFromProto(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Title, func(t *testing.T) {
-
 			got := userFromProto(tc.UserPB)
 			if reflect.DeepEqual(got, tc.ExpectUser) == false {
 				t.Errorf("expected returned asset to be %+v, was %+v", tc.ExpectUser, got)

--- a/internal/store/elasticsearch/discovery_repository.go
+++ b/internal/store/elasticsearch/discovery_repository.go
@@ -6,12 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/goto/salt/log"
 	"io"
 	"net/url"
 	"strings"
 
 	"github.com/goto/compass/core/asset"
+	"github.com/goto/salt/log"
 )
 
 // DiscoveryRepository implements discovery.Repository

--- a/internal/store/elasticsearch/discovery_search_repository_test.go
+++ b/internal/store/elasticsearch/discovery_search_repository_test.go
@@ -218,7 +218,7 @@ func TestSearcherSearch(t *testing.T) {
 					MaxResults: 5,
 				},
 				Expected: []expectedRow{
-					//{Type: "topic", AssetID: "consumer-topic"},
+					// {Type: "topic", AssetID: "consumer-topic"},
 					{Type: "topic", AssetID: "order-topic"},
 					{Type: "topic", AssetID: "purchase-topic"},
 					{Type: "topic", AssetID: "consumer-mq-2"},
@@ -268,7 +268,8 @@ func TestSearcherSearch(t *testing.T) {
 						Type:    "topic",
 						AssetID: "order-topic",
 						Data: map[string]interface{}{
-							"_highlight": map[string]interface{}{"urn": []interface{}{"<em>order</em>-topic"},
+							"_highlight": map[string]interface{}{
+								"urn":              []interface{}{"<em>order</em>-topic"},
 								"data.topic_name":  []interface{}{"<em>order</em>-topic"},
 								"name":             []interface{}{"<em>order</em>-topic"},
 								"description":      []interface{}{"Topic for each submitted <em>order</em>"},
@@ -347,16 +348,16 @@ func TestSearcherSuggest(t *testing.T) {
 	})
 }
 
-func loadTestFixture(cli *elasticsearch.Client, esClient *store.Client, filePath string) (err error) {
+func loadTestFixture(cli *elasticsearch.Client, esClient *store.Client, filePath string) error {
 	testFixtureJSON, err := os.ReadFile(filePath)
 	if err != nil {
-		return
+		return err
 	}
 
 	var data []searchTestData
 	err = json.Unmarshal(testFixtureJSON, &data)
 	if err != nil {
-		return
+		return err
 	}
 
 	ctx := context.TODO()
@@ -515,7 +516,8 @@ func TestGroupAssets(t *testing.T) {
 							{Name: "type", Value: "topic"},
 							{Name: "name", Value: "transaction"},
 						},
-						Assets: []asset.Asset{{Name: "transaction"}}},
+						Assets: []asset.Asset{{Name: "transaction"}},
+					},
 				},
 			},
 			{
@@ -562,7 +564,8 @@ func TestGroupAssets(t *testing.T) {
 				Expected: []asset.GroupResult{
 					{
 						Fields: []asset.GroupField{
-							{Name: "type", Value: "topic"}},
+							{Name: "type", Value: "topic"},
+						},
 						Assets: []asset.Asset{
 							{Name: "consumer-topic"},
 							{Name: "consumer-mq-2"},

--- a/internal/store/elasticsearch/es.go
+++ b/internal/store/elasticsearch/es.go
@@ -140,7 +140,7 @@ func (c *Client) Init() (string, error) {
 	if res.IsError() {
 		return "", errors.New(res.Status())
 	}
-	var info = struct {
+	info := struct {
 		ClusterName string `json:"cluster_name"`
 		Version     struct {
 			Number string `json:"number"`

--- a/internal/store/elasticsearch/es_test.go
+++ b/internal/store/elasticsearch/es_test.go
@@ -20,7 +20,7 @@ import (
 func TestElasticsearch(t *testing.T) {
 	ctx := context.Background()
 	t.Run("Create", func(t *testing.T) {
-		var testCases = []struct {
+		testCases := []struct {
 			Title      string
 			Service    string
 			ShouldFail bool
@@ -62,6 +62,7 @@ func TestElasticsearch(t *testing.T) {
 				Service: daggerService,
 				Validate: func(esClient *store.Client, cli *elasticsearch.Client, indexName string) error {
 					searchIndex := "universe"
+					//nolint:noctx
 					req, err := http.NewRequest("GET", "/_alias/"+searchIndex, nil)
 					if err != nil {
 						return fmt.Errorf("error creating request: %w", err)
@@ -91,6 +92,7 @@ func TestElasticsearch(t *testing.T) {
 					analyzerPath := fmt.Sprintf("/%s/_analyze", indexName)
 					analyzerPayload := fmt.Sprintf(`{"analyzer": "my_analyzer", "text": %q}`, textToAnalyze)
 
+					//nolint:noctx
 					req, err := http.NewRequest("POST", analyzerPath, strings.NewReader(analyzerPayload))
 					if err != nil {
 						return fmt.Errorf("error creating analyzer request: %w", err)
@@ -99,7 +101,7 @@ func TestElasticsearch(t *testing.T) {
 
 					res, err := cli.Perform(req)
 					if err != nil {
-						return fmt.Errorf("error invoking analyzer: %v", err)
+						return fmt.Errorf("invoke analyzer: %w", err)
 					}
 					defer res.Body.Close()
 					if res.StatusCode != http.StatusOK {

--- a/internal/store/postgres/asset_model.go
+++ b/internal/store/postgres/asset_model.go
@@ -33,7 +33,6 @@ type AssetModel struct {
 }
 
 func (a *AssetModel) toAsset(owners []user.User) asset.Asset {
-
 	return asset.Asset{
 		ID:          a.ID,
 		URN:         a.URN,
@@ -53,7 +52,6 @@ func (a *AssetModel) toAsset(owners []user.User) asset.Asset {
 }
 
 func (a *AssetModel) toAssetVersion() (asset.Asset, error) {
-
 	var clog diff.Changelog
 	err := a.Changelog.Unmarshal(&clog)
 	if err != nil {

--- a/internal/store/postgres/asset_repository_test.go
+++ b/internal/store/postgres/asset_repository_test.go
@@ -203,7 +203,8 @@ func (r *AssetRepositoryTestSuite) TestBuildFilterQuery() {
 			config: asset.Filter{
 				Data: map[string][]string{
 					"properties.attributes.entity": {"alpha", "beta"},
-				}},
+				},
+			},
 			expectedQuery: `(data->'properties'->'attributes'->>'entity' = $1 OR data->'properties'->'attributes'->>'entity' = $2)`,
 		},
 	}
@@ -621,7 +622,6 @@ func (r *AssetRepositoryTestSuite) TestGetByID() {
 	})
 
 	r.Run("return owners if any", func() {
-
 		ast := asset.Asset{
 			URN:     "urn-gbi-3",
 			Type:    "table",
@@ -1879,7 +1879,7 @@ func (r *AssetRepositoryTestSuite) insertProbes(t *testing.T) {
 	}
 }
 
-func (r *AssetRepositoryTestSuite) assertAsset(expectedAsset *asset.Asset, actualAsset *asset.Asset) bool {
+func (r *AssetRepositoryTestSuite) assertAsset(expectedAsset, actualAsset *asset.Asset) bool {
 	// sanitize time to make the assets comparable
 	expectedAsset.CreatedAt = time.Time{}
 	expectedAsset.UpdatedAt = time.Time{}
@@ -1901,7 +1901,7 @@ func clearTimestamps(ast *asset.Asset) {
 	ast.UpdatedAt = time.Time{}
 }
 
-func (r *AssetRepositoryTestSuite) assertProbe(t *testing.T, expected asset.Probe, actual asset.Probe) bool {
+func (r *AssetRepositoryTestSuite) assertProbe(t *testing.T, expected, actual asset.Probe) bool {
 	t.Helper()
 
 	return r.Equal(expected.AssetURN, actual.AssetURN) &&

--- a/internal/store/postgres/discussion_repository_test.go
+++ b/internal/store/postgres/discussion_repository_test.go
@@ -401,7 +401,8 @@ func (r *DiscussionRepositoryTestSuite) TestPatch() {
 			validateResult: func(r *DiscussionRepositoryTestSuite, result discussion.Discussion) {
 				r.Equal([]string(nil), result.Assignees)
 			},
-		}, {
+		},
+		{
 			description: "should return error if discussion id does not exist",
 			disc:        &discussion.Discussion{ID: "999", Assignees: []string{}},
 			err:         discussion.NotFoundError{DiscussionID: "999"},

--- a/internal/store/postgres/star_repository.go
+++ b/internal/store/postgres/star_repository.go
@@ -24,7 +24,7 @@ type StarRepository struct {
 }
 
 // Create insert a new record in the stars table
-func (r *StarRepository) Create(ctx context.Context, userID string, assetID string) (string, error) {
+func (r *StarRepository) Create(ctx context.Context, userID, assetID string) (string, error) {
 	var starID string
 	if userID == "" {
 		return "", star.ErrEmptyUserID
@@ -165,7 +165,7 @@ func (r *StarRepository) GetAllAssetsByUserID(ctx context.Context, flt star.Filt
 }
 
 // GetAssetByUserID fetch a specific starred asset by user id
-func (r *StarRepository) GetAssetByUserID(ctx context.Context, userID string, assetID string) (asset.Asset, error) {
+func (r *StarRepository) GetAssetByUserID(ctx context.Context, userID, assetID string) (asset.Asset, error) {
 	if userID == "" {
 		return asset.Asset{}, star.ErrEmptyUserID
 	}
@@ -222,7 +222,7 @@ func (r *StarRepository) GetAssetByUserID(ctx context.Context, userID string, as
 }
 
 // Delete will delete/unstar a starred asset for a user id
-func (r *StarRepository) Delete(ctx context.Context, userID string, assetID string) error {
+func (r *StarRepository) Delete(ctx context.Context, userID, assetID string) error {
 	if userID == "" {
 		return star.ErrEmptyUserID
 	}

--- a/internal/store/postgres/star_repository_test.go
+++ b/internal/store/postgres/star_repository_test.go
@@ -450,7 +450,6 @@ func (r *StarRepositoryTestSuite) TestDelete() {
 		r.Len(actualAssets, 2)
 		r.Contains(assetIDs, createdAsset1.ID)
 		r.Contains(assetIDs, createdAsset2.ID)
-
 	})
 }
 

--- a/internal/store/postgres/tag_model_test.go
+++ b/internal/store/postgres/tag_model_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestTagModel(t *testing.T) {
-
 	assetID := uuid.NewString()
 
 	templates := getTemplateModels()
@@ -23,10 +22,8 @@ func TestTagModel(t *testing.T) {
 		tagsMap := tags.buildMapByTemplateURN()
 
 		assert.EqualValues(t, expectedTagsMap, tagsMap)
-
 	})
 	t.Run("successfully build tags from tags model", func(t *testing.T) {
-
 		expectedTagDomains := []tag.Tag{
 			{
 				AssetID:     assetID,
@@ -49,10 +46,12 @@ func TestTagModel(t *testing.T) {
 						FieldDescription: "Email of the admin of the asset.",
 						FieldDataType:    "string",
 						FieldRequired:    true,
-					}},
+					},
+				},
 				TemplateDisplayName: "Governance Policy",
 				TemplateDescription: "Template that is mandatory to be used.",
-			}}
+			},
+		}
 
 		actualTagDomains := tags.toTags(assetID, templates)
 
@@ -61,7 +60,6 @@ func TestTagModel(t *testing.T) {
 }
 
 func TestTemplateModel(t *testing.T) {
-
 	templates := getTemplateModels()
 
 	t.Run("successfully convert template model to template", func(t *testing.T) {
@@ -95,7 +93,6 @@ func TestTemplateModel(t *testing.T) {
 	})
 
 	t.Run("successfully build from template model from template", func(t *testing.T) {
-
 		template := getTemplate()
 		option := "Public,Restricted"
 		expectedTemplateModel := &TagTemplateModel{
@@ -197,7 +194,6 @@ func TestTemplateFields(t *testing.T) {
 	templateModels := getTemplateModels()
 	templates := getTemplate()
 	t.Run("successfully build template models", func(t *testing.T) {
-
 		actualTemplateModels := tfs.toTemplateModels()
 
 		assert.EqualValues(t, templateModels[0], actualTemplateModels[0])
@@ -212,7 +208,6 @@ func TestTemplateFields(t *testing.T) {
 func TestTemplateTagFields(t *testing.T) {
 	ttfs := getTemplateTagFieldModels()
 	t.Run("successfully build templates model and tags model", func(t *testing.T) {
-
 		expectedTemplateModels := getTemplateModels()
 		expectedTagModels := getTagModels()
 		actualTemplateModels, actualTagModels := ttfs.toTemplateAndTagModels()

--- a/internal/store/postgres/tag_repository.go
+++ b/internal/store/postgres/tag_repository.go
@@ -83,7 +83,6 @@ func (r *TagRepository) Create(ctx context.Context, domainTag *tag.Tag) error {
 
 // Read reads tags grouped by its template
 func (r *TagRepository) Read(ctx context.Context, filter tag.Tag) ([]tag.Tag, error) {
-
 	if filter.AssetID == "" {
 		return nil, errEmptyAssetID
 	}

--- a/internal/store/postgres/tag_repository_test.go
+++ b/internal/store/postgres/tag_repository_test.go
@@ -200,8 +200,8 @@ func (r *TagRepositoryTestSuite) TestRead() {
 		err := setup(r.ctx, r.client)
 		r.NoError(err)
 
-		var assetID = uuid.NewString()
-		var templateURN = "governance_policy"
+		assetID := uuid.NewString()
+		templateURN := "governance_policy"
 
 		domainTemplate := getTemplate()
 		err = r.templateRepository.Create(r.ctx, domainTemplate)
@@ -226,8 +226,8 @@ func (r *TagRepositoryTestSuite) TestRead() {
 		err := setup(r.ctx, r.client)
 		r.NoError(err)
 
-		var assetID = domainAssetID
-		var templateURN = "governance_policy"
+		assetID := domainAssetID
+		templateURN := "governance_policy"
 
 		domainTemplate := getTemplate()
 		err = r.templateRepository.Create(r.ctx, domainTemplate)
@@ -373,8 +373,8 @@ func (r *TagRepositoryTestSuite) TestDelete() {
 		err := setup(r.ctx, r.client)
 		r.NoError(err)
 
-		var assetID = uuid.NewString()
-		var templateURN = "random-urn"
+		assetID := uuid.NewString()
+		templateURN := "random-urn"
 		paramDomainTag := tag.Tag{
 			AssetID:     assetID,
 			TemplateURN: templateURN,
@@ -388,7 +388,7 @@ func (r *TagRepositoryTestSuite) TestDelete() {
 		err := setup(r.ctx, r.client)
 		r.NoError(err)
 
-		var assetID = uuid.NewString()
+		assetID := uuid.NewString()
 		domainTemplate := getTemplate()
 		err = r.templateRepository.Create(r.ctx, domainTemplate)
 		r.NoError(err)

--- a/internal/store/postgres/tag_template_repository.go
+++ b/internal/store/postgres/tag_template_repository.go
@@ -15,9 +15,7 @@ const (
 	fieldOptionSeparator = ","
 )
 
-var (
-	errNilTemplate = errors.New("template is nil")
-)
+var errNilTemplate = errors.New("template is nil")
 
 // TagTemplateRepository is a type that manages template operation to the primary database
 type TagTemplateRepository struct {

--- a/internal/store/postgres/tag_template_repository_test.go
+++ b/internal/store/postgres/tag_template_repository_test.go
@@ -61,7 +61,6 @@ func (r *TagTemplateRepositoryTestSuite) TestNewRepository() {
 }
 
 func (r *TagTemplateRepositoryTestSuite) TestCreate() {
-
 	r.Run("should return error if template is nil", func() {
 		var template *tag.Template = nil
 

--- a/internal/store/postgres/user_model_test.go
+++ b/internal/store/postgres/user_model_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestUserModel(t *testing.T) {
-
 	t.Run("should return user domain entitiy", func(t *testing.T) {
 		someUUID := uuid.NewString()
 		timestamp := time.Now().UTC()

--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -3,7 +3,7 @@ package testutils
 import (
 	"fmt"
 	"testing"
-	
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"

--- a/pkg/grpc_interceptor/interceptor_test.go
+++ b/pkg/grpc_interceptor/interceptor_test.go
@@ -14,12 +14,6 @@ type dummyService struct {
 }
 
 func (s *dummyService) Ping(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.PingResponse, error) {
-	if ping.Value == "panic" {
-		panic("very bad thing happened")
-	}
-	if ping.Value == "nilpanic" {
-		panic(nil)
-	}
 	if ping.Value == "testuser" {
 		usr := user.FromContext(ctx)
 		if usr.UUID == "" {

--- a/pkg/statsd/metric.go
+++ b/pkg/statsd/metric.go
@@ -26,7 +26,7 @@ func (m *Metric) Success() *Metric {
 }
 
 // Failure tags the metric as failure.
-func (m *Metric) Failure(err error) *Metric {
+func (m *Metric) Failure() *Metric {
 	if m == nil {
 		return m
 	}
@@ -35,7 +35,7 @@ func (m *Metric) Failure(err error) *Metric {
 }
 
 // Tag adds a tag to the metric.
-func (m *Metric) Tag(key string, val string) *Metric {
+func (m *Metric) Tag(key, val string) *Metric {
 	if m == nil {
 		return nil
 	}
@@ -81,7 +81,7 @@ func (m *Metric) processTagsDatadog() []string {
 }
 
 func (m *Metric) processTagsInflux(name string, tags map[string]string) string {
-	var finalName = name
+	finalName := name
 	for k, v := range m.tags {
 		finalName = fmt.Sprintf("%s,%s=%s", finalName, k, v)
 	}

--- a/test/e2e_test/asset_test.go
+++ b/test/e2e_test/asset_test.go
@@ -89,7 +89,6 @@ func (r *AssetEndToEndTestSuite) TestAllNormalFlow() {
 	}
 	r.Equal(sampleAsset.Description, descriptionV3)
 	r.Equal(sampleAsset.Version, "0.3")
-
 }
 
 func (r *AssetEndToEndTestSuite) TestPatchAssetsAllFields() {
@@ -258,7 +257,6 @@ func (r *AssetEndToEndTestSuite) TestPatchAssetsAllFields() {
 	r.Equal("0.11", retrievedAsset.Version)
 	_, ok := retrievedAsset.Labels["label2"]
 	r.False(ok)
-
 }
 
 func generateAsset(urn, name string) asset.Asset {

--- a/test/e2e_test/helper_test.go
+++ b/test/e2e_test/helper_test.go
@@ -117,7 +117,7 @@ func (c *Client) GetAssetWithVersion(id, version string) (asset.Asset, error) {
 	return responsePayload.Data, nil
 }
 
-func (c *Client) makeRequest(method, url string, payload interface{}, data interface{}) (err error) {
+func (c *Client) makeRequest(method, url string, payload, data interface{}) (err error) {
 	jsonBytes, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("failed to encode the payload JSON: %w", err)


### PR DESCRIPTION
Address issues for the following linters:
- gofumpt
- gci
- errcheck
- gosec
- nakedret
- bodyclose
- errorlint
- govet
- noctx
- rowserrcheck
- sqlclosecheck
- gocritic: exitAfterDefer
- revive:
  - bare-return
  - deep-exit