### PR TITLE
fix: order asset probes by probe timestamp

### DIFF
--- a/internal/store/postgres/asset_repository.go
+++ b/internal/store/postgres/asset_repository.go
@@ -383,7 +383,7 @@ func (r *AssetRepository) GetProbes(ctx context.Context, assetURN string) ([]ass
 	query, args, err := sq.Select(
 		"id", "asset_urn", "status", "status_reason", "metadata", "timestamp", "created_at",
 	).From("asset_probes").
-		OrderBy("created_at").
+		OrderBy("timestamp").
 		Where(sq.Eq{"asset_urn": assetURN}).
 		PlaceholderFormat(sq.Dollar).
 		ToSql()

--- a/internal/store/postgres/asset_repository_test.go
+++ b/internal/store/postgres/asset_repository_test.go
@@ -1486,7 +1486,7 @@ func (r *AssetRepositoryTestSuite) TestGetProbes() {
 		r.Require().NoError(err)
 		r.Require().Len(actual, 3)
 
-		expected := []asset.Probe{p1, p2, p3}
+		expected := []asset.Probe{p2, p3, p1}
 		r.Equal(expected[0].ID, actual[0].ID)
 		r.Equal(expected[1].ID, actual[1].ID)
 		r.Equal(expected[2].ID, actual[2].ID)


### PR DESCRIPTION
Prefer asset probe timestamp over the timestamp when probe was created in the system.