### PR TITLE
fix: always output statsd metrics in DataDog format

### DIFF
--- a/pkg/statsd/config.go
+++ b/pkg/statsd/config.go
@@ -2,10 +2,9 @@ package statsd
 
 // Config represents configuration options for statsd reporter.
 type Config struct {
-	Enabled             bool    `mapstructure:"enabled" default:"false"`
-	Address             string  `mapstructure:"address" default:"127.0.0.1:8125"`
-	Prefix              string  `mapstructure:"prefix" default:"compassApi"`
-	SamplingRate        float64 `mapstructure:"sampling_rate" default:"1"`
-	Separator           string  `mapstructure:"separator" default:"."`
-	WithInfluxTagFormat bool    `mapstructure:"with_influx_tag_format" default:"true"`
+	Enabled      bool    `mapstructure:"enabled" default:"false"`
+	Address      string  `mapstructure:"address" default:"127.0.0.1:8125"`
+	Prefix       string  `mapstructure:"prefix" default:"compassApi"`
+	SamplingRate float64 `mapstructure:"sampling_rate" default:"1"`
+	Separator    string  `mapstructure:"separator" default:"."`
 }

--- a/pkg/statsd/statsd.go
+++ b/pkg/statsd/statsd.go
@@ -24,7 +24,8 @@ func Init(logger log.Logger, cfg Config) (*Reporter, error) {
 
 	client, err := std.New(cfg.Address,
 		std.WithNamespace(cfg.Prefix),
-		std.WithoutTelemetry())
+		std.WithoutTelemetry(),
+		std.WithoutOriginDetection())
 	if err != nil {
 		return nil, err
 	}
@@ -38,17 +39,16 @@ func Init(logger log.Logger, cfg Config) (*Reporter, error) {
 // Close closes statsd connection
 func (sd *Reporter) Close() {
 	if sd != nil && sd.client != nil {
-		sd.Close()
+		sd.client.Close()
 	}
 }
 
 // Incr returns a increment counter metric.
 func (sd *Reporter) Incr(name string) *Metric {
 	return &Metric{
-		rate:          sd.config.SamplingRate,
-		logger:        sd.logger,
-		name:          name,
-		withInfluxTag: sd.config.WithInfluxTagFormat,
+		rate:   sd.config.SamplingRate,
+		logger: sd.logger,
+		name:   name,
 		publishFunc: func(name string, tags []string, rate float64) error {
 			if sd == nil || sd.client == nil {
 				return nil
@@ -62,10 +62,9 @@ func (sd *Reporter) Incr(name string) *Metric {
 // Timing returns a timer metric.
 func (sd *Reporter) Timing(name string, value time.Duration) *Metric {
 	return &Metric{
-		rate:          sd.config.SamplingRate,
-		logger:        sd.logger,
-		name:          name,
-		withInfluxTag: sd.config.WithInfluxTagFormat,
+		rate:   sd.config.SamplingRate,
+		logger: sd.logger,
+		name:   name,
 		publishFunc: func(name string, tags []string, rate float64) error {
 			if sd == nil || sd.client == nil {
 				return nil
@@ -79,10 +78,9 @@ func (sd *Reporter) Timing(name string, value time.Duration) *Metric {
 // Gauge creates and returns a new gauge metric.
 func (sd *Reporter) Gauge(name string, value float64) *Metric {
 	return &Metric{
-		rate:          sd.config.SamplingRate,
-		logger:        sd.logger,
-		name:          name,
-		withInfluxTag: sd.config.WithInfluxTagFormat,
+		rate:   sd.config.SamplingRate,
+		logger: sd.logger,
+		name:   name,
 		publishFunc: func(name string, tags []string, rate float64) error {
 			if sd == nil || sd.client == nil {
 				return nil
@@ -96,10 +94,9 @@ func (sd *Reporter) Gauge(name string, value float64) *Metric {
 // Histogram creates and returns a rate & gauge metric.
 func (sd *Reporter) Histogram(name string, value float64) *Metric {
 	return &Metric{
-		rate:          sd.config.SamplingRate,
-		logger:        sd.logger,
-		name:          name,
-		withInfluxTag: sd.config.WithInfluxTagFormat,
+		rate:   sd.config.SamplingRate,
+		logger: sd.logger,
+		name:   name,
 		publishFunc: func(name string, tags []string, rate float64) error {
 			if sd == nil || sd.client == nil {
 				return nil


### PR DESCRIPTION
Trying to output metrics in influx format results in broken metric format that telegraf fails to parse.