### PR TITLE
feat: introduce exp. backoff for polling

### DIFF
--- a/compass.yaml.example
+++ b/compass.yaml.example
@@ -59,6 +59,7 @@ worker:
     enabled: true
     worker_count: 1
     poll_interval: 1s
+    active_poll_percent: 20
     pgq:
         host: localhost
         port: 5432

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -20,7 +20,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
-	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/newrelic/go-agent/v3/integrations/nrpgx" // register instrumented DB driver
 	"go.nhat.io/otelsql"
@@ -96,11 +95,12 @@ func (c *Client) Close() error {
 // NewClient initializes database connection
 func NewClient(ctx context.Context, cfg Config) (*Client, error) {
 	driverName, err := otelsql.Register(
-		"pgx",
+		"nrpgx",
 		otelsql.TraceQueryWithoutArgs(),
 		otelsql.TraceRowsClose(),
 		otelsql.TraceRowsAffected(),
 		otelsql.WithSystem(semconv.DBSystemPostgreSQL),
+		otelsql.WithInstanceName("default"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("register otelsql: %w", err)

--- a/internal/workermanager/worker_manager.go
+++ b/internal/workermanager/worker_manager.go
@@ -35,11 +35,12 @@ type Worker interface {
 }
 
 type Config struct {
-	Enabled        bool          `mapstructure:"enabled"`
-	WorkerCount    int           `mapstructure:"worker_count" default:"3"`
-	PollInterval   time.Duration `mapstructure:"poll_interval" default:"500ms"`
-	PGQ            pgq.Config    `mapstructure:"pgq"`
-	JobManagerPort int           `mapstructure:"job_manager_port"`
+	Enabled           bool          `mapstructure:"enabled"`
+	WorkerCount       int           `mapstructure:"worker_count" default:"3"`
+	PollInterval      time.Duration `mapstructure:"poll_interval" default:"500ms"`
+	ActivePollPercent float64       `mapstructure:"active_poll_percent" default:"20"`
+	PGQ               pgq.Config    `mapstructure:"pgq"`
+	JobManagerPort    int           `mapstructure:"job_manager_port"`
 }
 
 type Deps struct {
@@ -58,6 +59,7 @@ func New(ctx context.Context, deps Deps) (*Manager, error) {
 	w, err := worker.New(
 		workermw.WithJobProcessorInstrumentation()(processor),
 		worker.WithRunConfig(cfg.WorkerCount, cfg.PollInterval),
+		worker.WithActivePollPercent(cfg.ActivePollPercent),
 		worker.WithLogger(deps.Logger),
 	)
 	if err != nil {

--- a/pkg/worker/backoff_strategy.go
+++ b/pkg/worker/backoff_strategy.go
@@ -69,7 +69,12 @@ type ExponentialBackoff struct {
 }
 
 func (b *ExponentialBackoff) Backoff(attempt int) time.Duration {
-	duration := b.InitialDelay * time.Duration(math.Pow(b.Multiplier, float64(attempt-1)))
+	limit := (float64)(math.MaxInt64) / (float64)(b.InitialDelay)
+	multiplier := math.Pow(b.Multiplier, (float64)(attempt-1))
+	if multiplier > limit {
+		multiplier = limit
+	}
+	duration := b.InitialDelay * time.Duration(multiplier)
 
 	if b.MaxDelay > 0 && duration > b.MaxDelay {
 		duration = b.MaxDelay

--- a/pkg/worker/backoff_strategy_test.go
+++ b/pkg/worker/backoff_strategy_test.go
@@ -199,6 +199,16 @@ func TestExponentialBackoff(t *testing.T) {
 			attempt:  11,
 			expected: time.Second * 15,
 		},
+		7: {
+			b: &ExponentialBackoff{
+				Multiplier:   4,
+				InitialDelay: time.Second * 1,
+				MaxDelay:     time.Second * 10,
+				Jitter:       1,
+			},
+			attempt:  111,
+			expected: time.Second * 15,
+		},
 	}
 	for i, tc := range cases {
 		assert.Equal(t, tc.expected, tc.b.Backoff(tc.attempt), "test[%d]", i)

--- a/pkg/worker/pgq/pgq_processor.go
+++ b/pkg/worker/pgq/pgq_processor.go
@@ -36,6 +36,7 @@ func NewProcessor(ctx context.Context, cfg Config) (*Processor, error) {
 		otelsql.TraceRowsClose(),
 		otelsql.TraceRowsAffected(),
 		otelsql.WithSystem(semconv.DBSystemPostgreSQL),
+		otelsql.WithInstanceName("pgq"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new pgq processor: %w", err)
@@ -98,7 +99,7 @@ func (p *Processor) Process(ctx context.Context, types []string, fn worker.JobEx
 		job, err := p.pickupJob(ctx, tx, types)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return nil
+				return fmt.Errorf("pickup job: %w", worker.ErrNoJob)
 			}
 			return fmt.Errorf("pickup job: %w", err)
 		}

--- a/pkg/worker/pgq/pgq_processor_test.go
+++ b/pkg/worker/pgq/pgq_processor_test.go
@@ -154,7 +154,7 @@ func (s *ProcessorTestSuite) TestProcess() {
 			s.Fail("unexpected job invocation")
 			return job
 		})
-		s.NoError(err)
+		s.ErrorIs(err, worker.ErrNoJob)
 	})
 
 	s.Run("ProcessOnlyGivenTypes", func() {
@@ -168,7 +168,7 @@ func (s *ProcessorTestSuite) TestProcess() {
 			s.Fail("unexpected job invocation")
 			return job
 		})
-		s.NoError(err)
+		s.ErrorIs(err, worker.ErrNoJob)
 	})
 
 	s.Run("ProcessOnlyReadyJobs", func() {
@@ -184,7 +184,7 @@ func (s *ProcessorTestSuite) TestProcess() {
 			s.Fail("unexpected job invocation")
 			return job
 		})
-		s.NoError(err)
+		s.ErrorIs(err, worker.ErrNoJob)
 	})
 
 	s.Run("JobProcessedSuccessfully", func() {
@@ -296,7 +296,7 @@ func (s *ProcessorTestSuite) TestProcess() {
 				s.Fail("unexpected job invocation")
 				return job
 			})
-			s.NoError(err)
+			s.ErrorIs(err, worker.ErrNoJob)
 			return job
 		})
 		s.NoError(err)

--- a/pkg/worker/worker_option.go
+++ b/pkg/worker/worker_option.go
@@ -39,9 +39,17 @@ func WithRunConfig(workers int, pollInterval time.Duration) Option {
 	}
 }
 
+func WithActivePollPercent(pct float64) Option {
+	return func(w *Worker) error {
+		w.activePollPercent = pct
+		return nil
+	}
+}
+
 func withDefaults(opts []Option) []Option {
 	return append([]Option{
 		WithLogger(nil),
 		WithRunConfig(1, 1*time.Second),
+		WithActivePollPercent(20),
 	}, opts...)
 }


### PR DESCRIPTION
- Introduce active poll percent configuration to determine the
  percentage of workers that should actively poll as per the specified
  poll interval irrespective of whether a job was found or not.
- For a non-active poll worker, when no job is found, use exponential
  backoff to determine the poll delay for next attempt.
- Fix bug in exponential backoff calculation where it would return 0 as
  the backoff duration for high attempt number such as 70.
- Add instance name to otelsql instrumentation and use nrpgx driver for
  default PostgreSQL client (was missed).