### PR TITLE
perf: index asset_urn, timestamp cols in asset_probes tbl

### DIFF
--- a/internal/store/postgres/migrations/000017_create_idx_asset_probes_ts_table.down.sql
+++ b/internal/store/postgres/migrations/000017_create_idx_asset_probes_ts_table.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_asset_probes_ts;

--- a/internal/store/postgres/migrations/000017_create_idx_asset_probes_ts_table.up.sql
+++ b/internal/store/postgres/migrations/000017_create_idx_asset_probes_ts_table.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_asset_probes_ts ON asset_probes (timestamp);

--- a/internal/store/postgres/migrations/000018_create_idx_asset_probes_urn_table.down.sql
+++ b/internal/store/postgres/migrations/000018_create_idx_asset_probes_urn_table.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_asset_probes_urn;

--- a/internal/store/postgres/migrations/000018_create_idx_asset_probes_urn_table.up.sql
+++ b/internal/store/postgres/migrations/000018_create_idx_asset_probes_urn_table.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_asset_probes_urn ON asset_probes (asset_urn);


### PR DESCRIPTION
By default, golang-migrate wraps multiple SQL statements in a transaction.
Dropping index concurrently is not allowed in a transaction. So the drop
statement needs to be the only statement in the migration.

These indexes are necessary because we order by and filter the rows in asset_probes with these columns: 
- https://github.com/goto/compass/blob/v0.6.0/internal/store/postgres/asset_repository.go#L383-L389
- https://github.com/goto/compass/blob/v0.6.0/internal/store/postgres/asset_repository.go#L408-L428
