### PR TITLE
feat: log malformed data during upsert ES docs

### DIFF
--- a/internal/workermanager/discovery_worker.go
+++ b/internal/workermanager/discovery_worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/goto/compass/core/asset"
@@ -108,6 +109,10 @@ func (m *Manager) SyncAssets(ctx context.Context, job worker.JobSpec) error {
 
 		for _, ast := range assets {
 			if err := m.discoveryRepo.Upsert(ctx, ast); err != nil {
+				if strings.Contains(err.Error(), "illegal_argument_exception") {
+					m.logger.Error(err.Error())
+					continue
+				}
 				return err
 			}
 		}


### PR DESCRIPTION
- Log error related to malformed data type, due to ES cannot use `ignore_malformed` for object data type [[ref](https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-malformed.html)]