### PR TITLE
docs: delete assets api

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Discover why users choose Compass as their main data discovery and lineage servi
 
 Explore the following resources to get started with Compass:
 
-- [Guides](https://goto.github.io/compass/docs/guides) provides guidance on ingesting and querying metadata from Compass.
-- [Concepts](https://goto.github.io/compass/docs/concepts) describes all important Compass concepts.
-- [Reference](https://goto.github.io/compass/docs/reference) contains details about configurations, metrics and other aspects of Compass.
-- [Contribute](https://goto.github.io/compass/docs/contribute/contribution.md) contains resources for anyone who wants to contribute to Compass.
+- [Guides](https://goto.github.io/compass/guides/ingestion) provides guidance on ingesting and querying metadata from Compass.
+- [Concepts](https://goto.github.io/compass/concepts/overview) describes all important Compass concepts.
+- [Reference](https://goto.github.io/compass/reference/api) contains details about configurations, metrics and other aspects of Compass.
+- [Contribute](https://goto.github.io/compass/contribute/contributing) contains resources for anyone who wants to contribute to Compass.
 
 ## Installation
 
-Install Compass on macOS, Windows, Linux, OpenBSD, FreeBSD, and on any machine. <br/>Refer this for [installations](https://goto.github.io/compass/docs/installation) and [configurations](https://goto.github.io/compass/docs/guides/configuration)
+Install Compass on macOS, Windows, Linux, OpenBSD, FreeBSD, and on any machine. <br/>Refer this for [installations](https://goto.github.io/compass/installation) and [configurations](https://goto.github.io/compass/configuration)
 
 #### Binary (Cross-platform)
 
@@ -204,7 +204,7 @@ elasticsearch cluster, set the value of `ES_TEST_SERVER_URL` to the URL of the e
 
 Development of Compass happens in the open on GitHub, and we are grateful to the community for contributing bugfixes and improvements. Read below to learn how you can take part in improving Compass.
 
-Read our [contributing guide](https://goto.github.io/compass/docs/contribute/contribution.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to Compass.
+Read our [contributing guide](https://goto.github.io/compass/contribute/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to Compass.
 
 To help you get your feet wet and get you familiar with our contribution process, we have a list of [good first issues](https://github.com/goto/compass/labels/good%20first%20issue) that contain bugs which have a relatively limited scope. This is a great place to get started.
 

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -192,7 +192,10 @@ The query expr at least must consist `refreshed_at`, `type`, and `service` ident
 `type` and `service` identifiers valid only if it's using equals (`==`) or `IN` operator, to prevent human error on deleting assets.
 For example of the correct query:
 ```
-refreshed_at <= "2023-12-12 23:59:59" && service in ["service-1", "service-2"] && (type == "table" || data.foo != "bar")
+refreshed_at <= "2023-12-12 23:59:59" && service in ["service-1", "service-2"] && type == "table"
+```
+```
+refreshed_at <= (now() - duration('24h') && service == "service-1" && (type == "table" || data.foo != "bar")
 ```
 
 The idea of query expr converter is convert `query_expr` to AST (Abstract Syntax Tree), then make it as SQL Query and Elasticsearch Query so can used as filter query on deletion process.

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -192,11 +192,11 @@ The query expr at least must consist `refreshed_at`, `type`, and `service` ident
 `type` and `service` identifiers valid only if it's using equals (`==`) or `IN` operator, to prevent human error on deleting assets.
 For example of the correct query:
 ```
-refreshed_at <= "2023-12-12 23:59:59" && service in ["service-1", "service-2"] && (type == "table") || description != "definitely-active-asset")
+refreshed_at <= "2023-12-12 23:59:59" && service in ["service-1", "service-2"] && (type == "table") || data.foo != "bar")
 ```
 
 The idea of query expr converter is convert `query_expr` to AST (Abstract Syntax Tree), then make it as SQL Query and Elasticsearch Query so can used as filter query on deletion process.
-Currently, the expr query **already support most of the frequently used cases, except** ChainNode, MemberNode, SliceNode, CallNode, ClosureNode, PointerNode, VariableDeclaratorNode, MapNode, and PairNode.
+Currently, the expr query **already support most of the frequently used cases, except** ChainNode, SliceNode, CallNode, ClosureNode, PointerNode, VariableDeclaratorNode, MapNode, and PairNode.
 For more contexts, please refer to [AST Node](https://github.com/expr-lang/expr/blob/master/ast/node.go) in expr-lang library and [Query Expr Converter](https://github.com/goto/compass/tree/main/pkg/query_expr) in Compass.
 Example of **unsupported query for now** due to not directly produce a value is
 ```

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -212,10 +212,10 @@ However, **please do the best practice that try to simplify the query first** to
 
 ##### Parameters
 
-| Name       | Located in | Description                                                                                                                                                                                                                                                          | Required | Schema |
-|------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------| ------ |
+| Name       | Located in | Description                                                                                                                                                                                                                                                   | Required | Schema |
+|------------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------| ------ |
 | query_expr | body       | query expression based on [expr-lang](https://expr-lang.org/) to filtering the assets that wants to be deleted. `refreshed_at`, `type`, and `service` identifiers must exist in the query. The `type` and `service` must using equals (`==`) or `IN` operator | Yes      | string |
-| dry_run    | body       | if set to true, then deletion should not proceed and only return the affected rows. Else, will perform deletion in the background (default)                                                                                                                          | No       | string |
+| dry_run    | body       | (default: false) if set to true, deletion will not be executed but the number of rows matching the query is returned. Else, will perform deletion in the background (default)                                                                                 | No       | string |
 
 ##### Responses
 
@@ -1627,9 +1627,9 @@ Request to be sent to create a tag's template
 
 #### DeleteAssetsResponse
 
-| Name          | Type    | Description                                         | Required |
-|---------------|---------|-----------------------------------------------------|----------|
-| affected_rows | integer | the numbers of assets that match the given query | No       |
+| Name          | Type    | Description                                         |
+|---------------|---------|-----------------------------------------------------|
+| affected_rows | integer | the numbers of assets that match the given query |
 
 
 #### DeleteCommentResponse

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -189,6 +189,7 @@ Delete assets by [query expression](https://expr-lang.org/).
 
 Delete all assets that match the given [query expression](https://expr-lang.org/). 
 The query expr at least must consist `refreshed_at`, `type`, and `service` identifiers. 
+`type` and `service` identifiers valid only if it's using equals (`==`) or `IN` operator, to prevent human error on deleting assets.
 For example of the correct query:
 ```
 refreshed_at <= "2023-12-12 23:59:59" && service in ["service-1", "service-2"] && (type == "table") || description != "definitely-active-asset")
@@ -208,10 +209,10 @@ However, **please do the best practice that try to simplify the query first** to
 
 ##### Parameters
 
-| Name       | Located in | Description                                                                                                                                                                                                                                                                                                                                           | Required | Schema |
-|------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------| ------ |
-| query_expr | body       | query expression based on [expr-lang](https://expr-lang.org/) to filtering the assets that wants to be deleted. `refreshed_at`, `type`, and `service` identifiers must exist in the query.  | Yes      | string |
-| dry_run    | body       | if set to true, then deletion should not proceed and only return the affected rows. Else, will perform deletion in the background (default)                                                                                                                                                                                                           | No       | string |
+| Name       | Located in | Description                                                                                                                                                                                                                                                          | Required | Schema |
+|------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------| ------ |
+| query_expr | body       | query expression based on [expr-lang](https://expr-lang.org/) to filtering the assets that wants to be deleted. `refreshed_at`, `type`, and `service` identifiers must exist in the query. The `type` and `service` must using equals (`==`) or `IN` operator | Yes      | string |
+| dry_run    | body       | if set to true, then deletion should not proceed and only return the affected rows. Else, will perform deletion in the background (default)                                                                                                                          | No       | string |
 
 ##### Responses
 

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -192,7 +192,7 @@ The query expr at least must consist `refreshed_at`, `type`, and `service` ident
 `type` and `service` identifiers valid only if it's using equals (`==`) or `IN` operator, to prevent human error on deleting assets.
 For example of the correct query:
 ```
-refreshed_at <= "2023-12-12 23:59:59" && service in ["service-1", "service-2"] && (type == "table") || data.foo != "bar")
+refreshed_at <= "2023-12-12 23:59:59" && service in ["service-1", "service-2"] && (type == "table" || data.foo != "bar")
 ```
 
 The idea of query expr converter is convert `query_expr` to AST (Abstract Syntax Tree), then make it as SQL Query and Elasticsearch Query so can used as filter query on deletion process.

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -202,8 +202,8 @@ Example of **unsupported query for now** due to not directly produce a value is
 service in filter(assets, .Service startsWith "T")
 ```
 
-Complex query covered only if it directly produces a value, like `number_identifier == findLast([1, 2, 3, 4], # > 2)` will produce `number_identifier == 4`. 
-However, **please do the best practice that try to simplify the query first** to makes readable and prevent unwanted things like errors or false positive result. Like example before, please write `4` instead of `findLast([1, 2, 3, 4], # > 2)`. You can use [expr-lang playground](https://expr-lang.org/playground) to simplify the query expr.
+Complex query covered only if it directly produces a value, like `bool_identifier == !(findLast([1, 2, 3, 4], # > 2) == 4)` will produce `bool_identifier == false`. 
+However, **please do the best practice that try to simplify the query first** to makes readable and prevent unwanted things like errors or false positive result. Like example before, please write `false` instead of `!(findLast([1, 2, 3, 4], # > 2) == 4)`. You can use [expr-lang playground](https://expr-lang.org/playground) to simplify the query expr.
 
 
 ##### Parameters


### PR DESCRIPTION
**### Create Reference API for Delete Assets**

**Idea:**
`DeleteAssets` as DELETE `/v1/assets/`: an async API that will return how many rows that will affect based on filter criteria, and delete those rows from PostgreSQL (assets and lineage) and Elasticsearch in asynchronous.

**Request:**
- `query_expr` represent query expr for filter criteria: [https://github.com/expr-lang/expr](https://github.com/expr-lang/expr). 
- `dry_run` represent whether it only return how much affected rows (if set to true), or also perform deletion process in the background (default: false).

**Response:**
`affected_rows` represent how many rows that will affect based on filter criteria.

**Current Approach:**
- Query Expr --> AST --> SQL query and ES query.
- Use those query as WHERE clause in SQL and filter in ES query in deletion process, make this process in asynchronous.
- Return the affected rows