### PR TITLE
fix: race condition in both upsert post and upsert patch

### DIFF
--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -20,8 +20,8 @@ type Repository interface {
 	GetByVersionWithID(ctx context.Context, id, version string) (Asset, error)
 	GetByVersionWithURN(ctx context.Context, urn, version string) (Asset, error)
 	GetTypes(ctx context.Context, flt Filter) (map[Type]int, error)
-	Upsert(ctx context.Context, ast *Asset) (Asset, error)
-	UpsertPatch(ctx context.Context, ast *Asset, patchData map[string]interface{}) (Asset, error)
+	Upsert(ctx context.Context, ast *Asset) (string, error)
+	UpsertPatch(ctx context.Context, ast *Asset, patchData map[string]interface{}) (string, error)
 	DeleteByID(ctx context.Context, id string) error
 	DeleteByURN(ctx context.Context, urn string) error
 	DeleteByQueryExpr(ctx context.Context, queryExpr queryexpr.ExprStr) ([]string, error)

--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -20,7 +20,8 @@ type Repository interface {
 	GetByVersionWithID(ctx context.Context, id, version string) (Asset, error)
 	GetByVersionWithURN(ctx context.Context, urn, version string) (Asset, error)
 	GetTypes(ctx context.Context, flt Filter) (map[Type]int, error)
-	Upsert(ctx context.Context, ast *Asset) (string, error)
+	Upsert(ctx context.Context, ast *Asset) (Asset, error)
+	UpsertPatch(ctx context.Context, ast *Asset, patchData map[string]interface{}) (Asset, error)
 	DeleteByID(ctx context.Context, id string) error
 	DeleteByURN(ctx context.Context, urn string) error
 	DeleteByQueryExpr(ctx context.Context, queryExpr queryexpr.ExprStr) ([]string, error)

--- a/core/asset/errors.go
+++ b/core/asset/errors.go
@@ -13,6 +13,7 @@ var (
 	ErrEmptyQuery  = errors.New("query is empty")
 	ErrUnknownType = errors.New("unknown type")
 	ErrNilAsset    = errors.New("nil asset")
+	ErrURNExist    = errors.New("urn asset is already exist")
 )
 
 type NotFoundError struct {

--- a/core/asset/mocks/asset_repository.go
+++ b/core/asset/mocks/asset_repository.go
@@ -807,18 +807,18 @@ func (_c *AssetRepository_GetVersionHistory_Call) RunAndReturn(run func(context.
 }
 
 // Upsert provides a mock function with given fields: ctx, ast
-func (_m *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (string, error) {
+func (_m *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (asset.Asset, error) {
 	ret := _m.Called(ctx, ast)
 
-	var r0 string
+	var r0 asset.Asset
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) (string, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) (asset.Asset, error)); ok {
 		return rf(ctx, ast)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) string); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) asset.Asset); ok {
 		r0 = rf(ctx, ast)
 	} else {
-		r0 = ret.Get(0).(string)
+		r0 = ret.Get(0).(asset.Asset)
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *asset.Asset) error); ok {
@@ -849,12 +849,66 @@ func (_c *AssetRepository_Upsert_Call) Run(run func(ctx context.Context, ast *as
 	return _c
 }
 
-func (_c *AssetRepository_Upsert_Call) Return(_a0 string, _a1 error) *AssetRepository_Upsert_Call {
+func (_c *AssetRepository_Upsert_Call) Return(_a0 asset.Asset, _a1 error) *AssetRepository_Upsert_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AssetRepository_Upsert_Call) RunAndReturn(run func(context.Context, *asset.Asset) (string, error)) *AssetRepository_Upsert_Call {
+func (_c *AssetRepository_Upsert_Call) RunAndReturn(run func(context.Context, *asset.Asset) (asset.Asset, error)) *AssetRepository_Upsert_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpsertPatch provides a mock function with given fields: ctx, ast, patchData
+func (_m *AssetRepository) UpsertPatch(ctx context.Context, ast *asset.Asset, patchData map[string]interface{}) (asset.Asset, error) {
+	ret := _m.Called(ctx, ast, patchData)
+
+	var r0 asset.Asset
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) (asset.Asset, error)); ok {
+		return rf(ctx, ast, patchData)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) asset.Asset); ok {
+		r0 = rf(ctx, ast, patchData)
+	} else {
+		r0 = ret.Get(0).(asset.Asset)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *asset.Asset, map[string]interface{}) error); ok {
+		r1 = rf(ctx, ast, patchData)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AssetRepository_UpsertPatch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertPatch'
+type AssetRepository_UpsertPatch_Call struct {
+	*mock.Call
+}
+
+// UpsertPatch is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ast *asset.Asset
+//   - patchData map[string]interface{}
+func (_e *AssetRepository_Expecter) UpsertPatch(ctx interface{}, ast interface{}, patchData interface{}) *AssetRepository_UpsertPatch_Call {
+	return &AssetRepository_UpsertPatch_Call{Call: _e.mock.On("UpsertPatch", ctx, ast, patchData)}
+}
+
+func (_c *AssetRepository_UpsertPatch_Call) Run(run func(ctx context.Context, ast *asset.Asset, patchData map[string]interface{})) *AssetRepository_UpsertPatch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*asset.Asset), args[2].(map[string]interface{}))
+	})
+	return _c
+}
+
+func (_c *AssetRepository_UpsertPatch_Call) Return(_a0 asset.Asset, _a1 error) *AssetRepository_UpsertPatch_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *AssetRepository_UpsertPatch_Call) RunAndReturn(run func(context.Context, *asset.Asset, map[string]interface{}) (asset.Asset, error)) *AssetRepository_UpsertPatch_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/asset/mocks/asset_repository.go
+++ b/core/asset/mocks/asset_repository.go
@@ -807,18 +807,18 @@ func (_c *AssetRepository_GetVersionHistory_Call) RunAndReturn(run func(context.
 }
 
 // Upsert provides a mock function with given fields: ctx, ast
-func (_m *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (asset.Asset, error) {
+func (_m *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (string, error) {
 	ret := _m.Called(ctx, ast)
 
-	var r0 asset.Asset
+	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) (asset.Asset, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) (string, error)); ok {
 		return rf(ctx, ast)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) asset.Asset); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) string); ok {
 		r0 = rf(ctx, ast)
 	} else {
-		r0 = ret.Get(0).(asset.Asset)
+		r0 = ret.Get(0).(string)
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *asset.Asset) error); ok {
@@ -849,29 +849,29 @@ func (_c *AssetRepository_Upsert_Call) Run(run func(ctx context.Context, ast *as
 	return _c
 }
 
-func (_c *AssetRepository_Upsert_Call) Return(_a0 asset.Asset, _a1 error) *AssetRepository_Upsert_Call {
+func (_c *AssetRepository_Upsert_Call) Return(_a0 string, _a1 error) *AssetRepository_Upsert_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AssetRepository_Upsert_Call) RunAndReturn(run func(context.Context, *asset.Asset) (asset.Asset, error)) *AssetRepository_Upsert_Call {
+func (_c *AssetRepository_Upsert_Call) RunAndReturn(run func(context.Context, *asset.Asset) (string, error)) *AssetRepository_Upsert_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpsertPatch provides a mock function with given fields: ctx, ast, patchData
-func (_m *AssetRepository) UpsertPatch(ctx context.Context, ast *asset.Asset, patchData map[string]interface{}) (asset.Asset, error) {
+func (_m *AssetRepository) UpsertPatch(ctx context.Context, ast *asset.Asset, patchData map[string]interface{}) (string, error) {
 	ret := _m.Called(ctx, ast, patchData)
 
-	var r0 asset.Asset
+	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) (asset.Asset, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) (string, error)); ok {
 		return rf(ctx, ast, patchData)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) asset.Asset); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) string); ok {
 		r0 = rf(ctx, ast, patchData)
 	} else {
-		r0 = ret.Get(0).(asset.Asset)
+		r0 = ret.Get(0).(string)
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *asset.Asset, map[string]interface{}) error); ok {
@@ -903,12 +903,12 @@ func (_c *AssetRepository_UpsertPatch_Call) Run(run func(ctx context.Context, as
 	return _c
 }
 
-func (_c *AssetRepository_UpsertPatch_Call) Return(_a0 asset.Asset, _a1 error) *AssetRepository_UpsertPatch_Call {
+func (_c *AssetRepository_UpsertPatch_Call) Return(_a0 string, _a1 error) *AssetRepository_UpsertPatch_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AssetRepository_UpsertPatch_Call) RunAndReturn(run func(context.Context, *asset.Asset, map[string]interface{}) (asset.Asset, error)) *AssetRepository_UpsertPatch_Call {
+func (_c *AssetRepository_UpsertPatch_Call) RunAndReturn(run func(context.Context, *asset.Asset, map[string]interface{}) (string, error)) *AssetRepository_UpsertPatch_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/asset/patch.go
+++ b/core/asset/patch.go
@@ -13,6 +13,7 @@ func patchAsset(a *Asset, patchData map[string]interface{}) {
 	a.Name = patchString("name", patchData, a.Name)
 	a.Description = patchString("description", patchData, a.Description)
 	a.URL = patchString("url", patchData, a.URL)
+	a.UpdatedBy.ID = patchString("updated_by", patchData, a.UpdatedBy.ID)
 
 	labels, exists := patchData["labels"]
 	if exists {

--- a/core/asset/service.go
+++ b/core/asset/service.go
@@ -106,16 +106,16 @@ func (s *Service) UpsertAssetWithoutLineage(ctx context.Context, ast *Asset) (st
 	currentTime := time.Now()
 	ast.RefreshedAt = &currentTime
 
-	newAsset, err := s.assetRepository.Upsert(ctx, ast)
+	assetID, err := s.assetRepository.Upsert(ctx, ast)
 	if err != nil {
 		return "", err
 	}
 
-	if err := s.worker.EnqueueIndexAssetJob(ctx, newAsset); err != nil {
+	if err := s.worker.EnqueueIndexAssetJob(ctx, *ast); err != nil {
 		return "", err
 	}
 
-	return newAsset.ID, nil
+	return assetID, nil
 }
 
 func (s *Service) UpsertPatchAsset(ctx context.Context, ast *Asset, upstreams, downstreams []string, patchData map[string]interface{}) (string, error) {
@@ -135,16 +135,16 @@ func (s *Service) UpsertPatchAssetWithoutLineage(ctx context.Context, ast *Asset
 	currentTime := time.Now()
 	ast.RefreshedAt = &currentTime
 
-	newAsset, err := s.assetRepository.UpsertPatch(ctx, ast, patchData)
+	assetID, err := s.assetRepository.UpsertPatch(ctx, ast, patchData)
 	if err != nil {
 		return "", err
 	}
 
-	if err := s.worker.EnqueueIndexAssetJob(ctx, newAsset); err != nil {
+	if err := s.worker.EnqueueIndexAssetJob(ctx, *ast); err != nil {
 		return "", err
 	}
 
-	return newAsset.ID, nil
+	return assetID, nil
 }
 
 func (s *Service) DeleteAsset(ctx context.Context, id string) (err error) {

--- a/core/asset/service.go
+++ b/core/asset/service.go
@@ -111,6 +111,7 @@ func (s *Service) UpsertAssetWithoutLineage(ctx context.Context, ast *Asset) (st
 		return "", err
 	}
 
+	ast.ID = assetID
 	if err := s.worker.EnqueueIndexAssetJob(ctx, *ast); err != nil {
 		return "", err
 	}
@@ -140,6 +141,7 @@ func (s *Service) UpsertPatchAssetWithoutLineage(ctx context.Context, ast *Asset
 		return "", err
 	}
 
+	ast.ID = assetID
 	if err := s.worker.EnqueueIndexAssetJob(ctx, *ast); err != nil {
 		return "", err
 	}

--- a/core/asset/service.go
+++ b/core/asset/service.go
@@ -108,8 +108,8 @@ func (s *Service) UpsertAssetWithoutLineage(ctx context.Context, ast *Asset) (st
 	ast.RefreshedAt = &currentTime
 
 	assetID, err := s.assetRepository.Upsert(ctx, ast)
-	// retry possibility due to race condition
-	if err != nil && errors.Is(err, ErrURNExist) {
+	// retry due to race condition possibility on insert
+	if errors.Is(err, ErrURNExist) {
 		assetID, err = s.assetRepository.Upsert(ctx, ast)
 	}
 	if err != nil {
@@ -142,8 +142,8 @@ func (s *Service) UpsertPatchAssetWithoutLineage(ctx context.Context, ast *Asset
 	ast.RefreshedAt = &currentTime
 
 	assetID, err := s.assetRepository.UpsertPatch(ctx, ast, patchData)
-	// retry possibility due to race condition
-	if err != nil && errors.Is(err, ErrURNExist) {
+	// retry due to race condition possibility on insert
+	if errors.Is(err, ErrURNExist) {
 		assetID, err = s.assetRepository.UpsertPatch(ctx, ast, patchData)
 	}
 	if err != nil {

--- a/core/asset/service_test.go
+++ b/core/asset/service_test.go
@@ -194,7 +194,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return("", errors.New("unknown error"))
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(asset.Asset{}, errors.New("unknown error"))
 			},
 			Err:        errors.New("unknown error"),
 			ReturnedID: "",
@@ -203,7 +203,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Description: `should return error if discovery repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset.ID, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(errors.New("unknown error"))
 			},
 			Err:        errors.New("unknown error"),
@@ -215,7 +215,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Upstreams:   sampleNodes1,
 			Downstreams: sampleNodes2,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset.ID, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 				lr.EXPECT().Upsert(ctx, sampleAsset.URN, sampleNodes1, sampleNodes2).Return(errors.New("unknown error"))
 			},
@@ -228,7 +228,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Upstreams:   sampleNodes1,
 			Downstreams: sampleNodes2,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset.ID, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 				lr.EXPECT().Upsert(ctx, sampleAsset.URN, sampleNodes1, sampleNodes2).Return(nil)
 			},
@@ -279,7 +279,7 @@ func TestService_UpsertAssetWithoutLineage(t *testing.T) {
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return("", errors.New("unknown error"))
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(asset.Asset{}, errors.New("unknown error"))
 			},
 			Err: errors.New("unknown error"),
 		},
@@ -287,7 +287,7 @@ func TestService_UpsertAssetWithoutLineage(t *testing.T) {
 			Description: `should return error if discovery repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset.ID, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(errors.New("unknown error"))
 			},
 			Err: errors.New("unknown error"),
@@ -296,7 +296,7 @@ func TestService_UpsertAssetWithoutLineage(t *testing.T) {
 			Description: `should return no error if all repositories upsert return no error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset.ID, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 			},
 			ReturnedID: sampleAsset.ID,

--- a/core/asset/service_test.go
+++ b/core/asset/service_test.go
@@ -349,7 +349,7 @@ func TestService_UpsertPatchAsset(t *testing.T) {
 		{
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
-			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
+			Setup: func(ctx context.Context, ar *mocks.AssetRepository, _ *mocks.DiscoveryRepository, _ *mocks.LineageRepository) {
 				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return("", errors.New("unknown error"))
 			},
 			Err:        errors.New("unknown error"),
@@ -358,7 +358,7 @@ func TestService_UpsertPatchAsset(t *testing.T) {
 		{
 			Description: `should return error if discovery repository upsert return error`,
 			Asset:       sampleAsset,
-			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
+			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, _ *mocks.LineageRepository) {
 				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(sampleAsset.ID, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(errors.New("unknown error"))
 			},
@@ -435,7 +435,7 @@ func TestService_UpsertPatchAssetWithoutLineage(t *testing.T) {
 		{
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
-			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
+			Setup: func(ctx context.Context, ar *mocks.AssetRepository, _ *mocks.DiscoveryRepository) {
 				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return("", errors.New("unknown error"))
 			},
 			Err: errors.New("unknown error"),

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/jackc/pgconn v1.10.0
 	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
 	github.com/jackc/pgx/v4 v4.13.0
+	github.com/jinzhu/copier v0.4.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/lib/pq v1.10.2
 	github.com/newrelic/go-agent/v3 v3.15.2

--- a/go.sum
+++ b/go.sum
@@ -867,6 +867,8 @@ github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jeremywohl/flatten v1.0.1 h1:LrsxmB3hfwJuE+ptGOijix1PIfOoKLJ3Uee/mzbgtrs=
 github.com/jeremywohl/flatten v1.0.1/go.mod h1:4AmD/VxjWcI5SRB0n6szE2A6s2fsNHDLO0nAlMHgfLQ=
+github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
+github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/internal/server/v1beta1/mocks/asset_service.go
+++ b/internal/server/v1beta1/mocks/asset_service.go
@@ -867,6 +867,116 @@ func (_c *AssetService_UpsertAssetWithoutLineage_Call) RunAndReturn(run func(con
 	return _c
 }
 
+// UpsertPatchAsset provides a mock function with given fields: ctx, ast, upstreams, downstreams, patchData
+func (_m *AssetService) UpsertPatchAsset(ctx context.Context, ast *asset.Asset, upstreams []string, downstreams []string, patchData map[string]interface{}) (string, error) {
+	ret := _m.Called(ctx, ast, upstreams, downstreams, patchData)
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, []string, []string, map[string]interface{}) (string, error)); ok {
+		return rf(ctx, ast, upstreams, downstreams, patchData)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, []string, []string, map[string]interface{}) string); ok {
+		r0 = rf(ctx, ast, upstreams, downstreams, patchData)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *asset.Asset, []string, []string, map[string]interface{}) error); ok {
+		r1 = rf(ctx, ast, upstreams, downstreams, patchData)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AssetService_UpsertPatchAsset_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertPatchAsset'
+type AssetService_UpsertPatchAsset_Call struct {
+	*mock.Call
+}
+
+// UpsertPatchAsset is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ast *asset.Asset
+//   - upstreams []string
+//   - downstreams []string
+//   - patchData map[string]interface{}
+func (_e *AssetService_Expecter) UpsertPatchAsset(ctx interface{}, ast interface{}, upstreams interface{}, downstreams interface{}, patchData interface{}) *AssetService_UpsertPatchAsset_Call {
+	return &AssetService_UpsertPatchAsset_Call{Call: _e.mock.On("UpsertPatchAsset", ctx, ast, upstreams, downstreams, patchData)}
+}
+
+func (_c *AssetService_UpsertPatchAsset_Call) Run(run func(ctx context.Context, ast *asset.Asset, upstreams []string, downstreams []string, patchData map[string]interface{})) *AssetService_UpsertPatchAsset_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*asset.Asset), args[2].([]string), args[3].([]string), args[4].(map[string]interface{}))
+	})
+	return _c
+}
+
+func (_c *AssetService_UpsertPatchAsset_Call) Return(_a0 string, _a1 error) *AssetService_UpsertPatchAsset_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *AssetService_UpsertPatchAsset_Call) RunAndReturn(run func(context.Context, *asset.Asset, []string, []string, map[string]interface{}) (string, error)) *AssetService_UpsertPatchAsset_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpsertPatchAssetWithoutLineage provides a mock function with given fields: ctx, ast, patchData
+func (_m *AssetService) UpsertPatchAssetWithoutLineage(ctx context.Context, ast *asset.Asset, patchData map[string]interface{}) (string, error) {
+	ret := _m.Called(ctx, ast, patchData)
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) (string, error)); ok {
+		return rf(ctx, ast, patchData)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) string); ok {
+		r0 = rf(ctx, ast, patchData)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *asset.Asset, map[string]interface{}) error); ok {
+		r1 = rf(ctx, ast, patchData)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AssetService_UpsertPatchAssetWithoutLineage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertPatchAssetWithoutLineage'
+type AssetService_UpsertPatchAssetWithoutLineage_Call struct {
+	*mock.Call
+}
+
+// UpsertPatchAssetWithoutLineage is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ast *asset.Asset
+//   - patchData map[string]interface{}
+func (_e *AssetService_Expecter) UpsertPatchAssetWithoutLineage(ctx interface{}, ast interface{}, patchData interface{}) *AssetService_UpsertPatchAssetWithoutLineage_Call {
+	return &AssetService_UpsertPatchAssetWithoutLineage_Call{Call: _e.mock.On("UpsertPatchAssetWithoutLineage", ctx, ast, patchData)}
+}
+
+func (_c *AssetService_UpsertPatchAssetWithoutLineage_Call) Run(run func(ctx context.Context, ast *asset.Asset, patchData map[string]interface{})) *AssetService_UpsertPatchAssetWithoutLineage_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*asset.Asset), args[2].(map[string]interface{}))
+	})
+	return _c
+}
+
+func (_c *AssetService_UpsertPatchAssetWithoutLineage_Call) Return(_a0 string, _a1 error) *AssetService_UpsertPatchAssetWithoutLineage_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *AssetService_UpsertPatchAssetWithoutLineage_Call) RunAndReturn(run func(context.Context, *asset.Asset, map[string]interface{}) (string, error)) *AssetService_UpsertPatchAssetWithoutLineage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 type mockConstructorTestingTNewAssetService interface {
 	mock.TestingT
 	Cleanup(func())

--- a/internal/store/postgres/asset_repository.go
+++ b/internal/store/postgres/asset_repository.go
@@ -350,7 +350,7 @@ func (r *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (string,
 			return fmt.Errorf("error diffing two assets: %w", err)
 		}
 
-		err = r.update(ctx, tx, fetchedAsset.ID, ast, &fetchedAsset, changelog)
+		err = r.update(ctx, tx, ast, &fetchedAsset, changelog)
 		if err != nil {
 			return fmt.Errorf("error updating asset to DB: %w", err)
 		}
@@ -610,7 +610,8 @@ func (r *AssetRepository) insert(ctx context.Context, ast *asset.Asset) (string,
 	return id, nil
 }
 
-func (r *AssetRepository) update(ctx context.Context, tx *sqlx.Tx, assetID string, newAsset, oldAsset *asset.Asset, clog diff.Changelog) error {
+func (r *AssetRepository) update(ctx context.Context, tx *sqlx.Tx, newAsset, oldAsset *asset.Asset, clog diff.Changelog) error {
+	assetID := newAsset.ID
 	if !isValidUUID(assetID) {
 		return asset.InvalidError{AssetID: assetID}
 	}

--- a/internal/store/postgres/asset_repository.go
+++ b/internal/store/postgres/asset_repository.go
@@ -611,7 +611,7 @@ func (r *AssetRepository) insert(ctx context.Context, ast *asset.Asset) (string,
 }
 
 func (r *AssetRepository) update(ctx context.Context, tx *sqlx.Tx, newAsset, oldAsset *asset.Asset, clog diff.Changelog) error {
-	assetID := newAsset.ID
+	assetID := oldAsset.ID
 	if !isValidUUID(assetID) {
 		return asset.InvalidError{AssetID: assetID}
 	}

--- a/internal/store/postgres/asset_repository.go
+++ b/internal/store/postgres/asset_repository.go
@@ -668,6 +668,10 @@ func (r *AssetRepository) insert(ctx context.Context, tx *sqlx.Tx, ast *asset.As
 	var id string
 	err = tx.QueryRowContext(ctx, query, args...).Scan(&id)
 	if err != nil {
+		if strings.Contains(err.Error(), "assets_idx_urn") {
+			return "", asset.ErrURNExist
+		}
+
 		return "", fmt.Errorf("run insert query: %w", err)
 	}
 	ast.ID = id

--- a/internal/store/postgres/asset_repository_test.go
+++ b/internal/store/postgres/asset_repository_test.go
@@ -1298,7 +1298,7 @@ func (r *AssetRepositoryTestSuite) TestUpsertRaceCondition() {
 
 				localAst := ast
 				localAst.URL = fmt.Sprintf("https://sample-url-%d.com", index)
-				_, err := r.repository.Upsert(r.ctx, &localAst)
+				_, err := r.repository.Upsert(context.Background(), &localAst)
 
 				mu.Lock()
 				results = append(results, err)
@@ -1309,8 +1309,7 @@ func (r *AssetRepositoryTestSuite) TestUpsertRaceCondition() {
 		wg.Wait()
 
 		// Check for errors
-		for i, err := range results {
-			fmt.Println("err", i, ": ", err)
+		for _, err := range results {
 			assert.NoError(r.T(), err, "Upsert should not fail under race conditions")
 		}
 	})

--- a/internal/store/postgres/asset_repository_test.go
+++ b/internal/store/postgres/asset_repository_test.go
@@ -119,9 +119,10 @@ func (r *AssetRepositoryTestSuite) insertRecord() (assets []asset.Asset) {
 			UpdatedBy:   r.users[0],
 		}
 
-		upsertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+		id, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(upsertedAsset.ID)
+		r.Require().NotEmpty(id)
+		ast.ID = id
 		assets = append(assets, ast)
 	}
 
@@ -562,9 +563,10 @@ func (r *AssetRepositoryTestSuite) TestGetCount() {
 			Service:   service[0],
 			UpdatedBy: r.users[0],
 		}
-		upsertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+		id, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(upsertedAsset.ID)
+		r.Require().NotEmpty(id)
+		ast.ID = id
 	}
 
 	r.Run("should return total assets with filter", func() {
@@ -607,17 +609,20 @@ func (r *AssetRepositoryTestSuite) TestGetByID() {
 		}
 
 		var err error
-		upsertedAsset1, err := r.repository.Upsert(r.ctx, &asset1)
+		id, err := r.repository.Upsert(r.ctx, &asset1)
 		r.Require().NoError(err)
-		r.NotEmpty(upsertedAsset1.ID)
+		r.NotEmpty(id)
+		asset1.ID = id
 
-		upsertedAsset2, err := r.repository.Upsert(r.ctx, &asset2)
+		id, err = r.repository.Upsert(r.ctx, &asset2)
 		r.Require().NoError(err)
-		r.NotEmpty(upsertedAsset2.ID)
+		r.NotEmpty(id)
+		asset2.ID = id
 
-		result, err := r.repository.GetByID(r.ctx, upsertedAsset2.ID)
+		result, err := r.repository.GetByID(r.ctx, asset2.ID)
 		r.NoError(err)
-		r.assertAsset(&upsertedAsset2, &result)
+		asset2.UpdatedBy = r.users[1]
+		r.assertAsset(&asset2, &result)
 	})
 
 	r.Run("return owners if any", func() {
@@ -632,12 +637,15 @@ func (r *AssetRepositoryTestSuite) TestGetByID() {
 			UpdatedBy: r.users[1],
 		}
 
-		upsertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+		id, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(upsertedAsset.ID)
+		r.Require().NotEmpty(id)
+		ast.ID = id
 
-		r.Len(upsertedAsset.Owners, len(ast.Owners))
-		for i, owner := range upsertedAsset.Owners {
+		result, err := r.repository.GetByID(r.ctx, ast.ID)
+		r.NoError(err)
+		r.Len(result.Owners, len(ast.Owners))
+		for i, owner := range result.Owners {
 			r.Equal(ast.Owners[i].ID, owner.ID)
 		}
 	})
@@ -666,13 +674,15 @@ func (r *AssetRepositoryTestSuite) TestGetByURN() {
 			UpdatedBy: r.users[1],
 		}
 
-		upsertedAsset, err := r.repository.Upsert(r.ctx, &asset1)
+		id, err := r.repository.Upsert(r.ctx, &asset1)
 		r.Require().NoError(err)
-		r.NotEmpty(upsertedAsset.ID)
+		r.NotEmpty(id)
+		asset1.ID = id
 
-		upsertedAsset, err = r.repository.Upsert(r.ctx, &asset2)
+		id, err = r.repository.Upsert(r.ctx, &asset2)
 		r.Require().NoError(err)
-		r.NotEmpty(upsertedAsset.ID)
+		r.NotEmpty(id)
+		asset2.ID = id
 
 		result, err := r.repository.GetByURN(r.ctx, "urn-gbi-2")
 		r.NoError(err)
@@ -715,15 +725,16 @@ func (r *AssetRepositoryTestSuite) TestVersions() {
 		RefreshedAt: &currentTime,
 	}
 
-	upsertedAsset, err := r.repository.Upsert(r.ctx, &astVersioning)
+	id, err := r.repository.Upsert(r.ctx, &astVersioning)
 	r.Require().NoError(err)
-	r.Require().NotEmpty(upsertedAsset.ID)
+	r.Require().NotEmpty(id)
+	astVersioning.ID = id
 
 	// v0.2
 	astVersioning.Description = "new description in v0.2"
-	upsertedAsset, err = r.repository.Upsert(r.ctx, &astVersioning)
+	id, err = r.repository.Upsert(r.ctx, &astVersioning)
 	r.Require().NoError(err)
-	r.Require().Equal(upsertedAsset.ID, astVersioning.ID)
+	r.Require().Equal(id, astVersioning.ID)
 
 	// v0.3
 	astVersioning.Owners = []user.User{
@@ -735,26 +746,26 @@ func (r *AssetRepositoryTestSuite) TestVersions() {
 			Provider: "meteor",
 		},
 	}
-	upsertedAsset, err = r.repository.Upsert(r.ctx, &astVersioning)
+	id, err = r.repository.Upsert(r.ctx, &astVersioning)
 	r.Require().NoError(err)
-	r.Require().Equal(upsertedAsset.ID, astVersioning.ID)
+	r.Require().Equal(id, astVersioning.ID)
 
 	// v0.4
 	astVersioning.Data = map[string]interface{}{
 		"data1": float64(12345),
 	}
-	upsertedAsset, err = r.repository.Upsert(r.ctx, &astVersioning)
+	id, err = r.repository.Upsert(r.ctx, &astVersioning)
 	r.Require().NoError(err)
-	r.Require().Equal(upsertedAsset.ID, astVersioning.ID)
+	r.Require().Equal(id, astVersioning.ID)
 
 	// v0.5
 	astVersioning.Labels = map[string]string{
 		"key1": "value1",
 	}
 
-	upsertedAsset, err = r.repository.Upsert(r.ctx, &astVersioning)
+	id, err = r.repository.Upsert(r.ctx, &astVersioning)
 	r.Require().NoError(err)
-	r.Require().Equal(upsertedAsset.ID, astVersioning.ID)
+	r.Require().Equal(id, astVersioning.ID)
 
 	r.Run("should return current version of an assets", func() {
 		expected := asset.Asset{
@@ -885,15 +896,16 @@ func (r *AssetRepositoryTestSuite) TestVersions() {
 			Service:   "bigquery",
 			UpdatedBy: r.users[1],
 		}
-		upsertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+		id, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(upsertedAsset.ID)
+		r.Require().NotEmpty(id)
+		ast.ID = id
 
 		for i := 2; i < 100; i++ {
 			ast.Description = "new description in v0." + strconv.Itoa(i)
-			upsertedAsset, err = r.repository.Upsert(r.ctx, &ast)
+			id, err = r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.Require().Equal(upsertedAsset.ID, ast.ID)
+			r.Require().Equal(id, ast.ID)
 		}
 
 		expected := []asset.Asset{
@@ -950,15 +962,16 @@ func (r *AssetRepositoryTestSuite) TestVersions() {
 			Service:   "bigquery",
 			UpdatedBy: r.users[1],
 		}
-		upsertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+		id, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(upsertedAsset.ID)
+		r.Require().NotEmpty(id)
+		ast.ID = id
 
 		for i := 2; i < 100; i++ {
 			ast.Description = "new description in v0." + strconv.Itoa(i)
-			upsertedAsset, err = r.repository.Upsert(r.ctx, &ast)
+			id, err = r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.Require().Equal(upsertedAsset.ID, ast.ID)
+			r.Require().Equal(id, ast.ID)
 		}
 
 		assetVersions, err := r.repository.GetVersionHistory(r.ctx, asset.Filter{Size: 0, Offset: 86}, ast.ID)
@@ -979,40 +992,41 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 	r.Run("on insert", func() {
 		r.Run("set ID to asset and version to base version", func() {
 			ast := asset.Asset{
-				URN:         "urn-u-1",
+				URN:         uuid.NewString() + "urn-u-1",
 				Type:        "table",
 				Service:     "bigquery",
 				URL:         "https://sample-url.com",
 				UpdatedBy:   r.users[0],
 				RefreshedAt: &refreshedAtTime,
 			}
-			upsertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+			id, err := r.repository.Upsert(r.ctx, &ast)
 			r.Equal(asset.BaseVersion, ast.Version)
 			r.NoError(err)
-			r.NotEmpty(upsertedAsset.ID)
+			r.NotEmpty(id)
 			r.NotEmpty(ast.CreatedAt)
 			r.NotEmpty(ast.UpdatedAt)
+			ast.ID = id
 
-			assetInDB, err := r.repository.GetByID(r.ctx, upsertedAsset.ID)
+			assetInDB, err := r.repository.GetByID(r.ctx, ast.ID)
 			r.Require().NoError(err)
 			r.NotEqual(time.Time{}, assetInDB.CreatedAt)
 			r.NotEqual(time.Time{}, assetInDB.UpdatedAt)
 			r.assertAsset(&ast, &assetInDB)
 
-			ast2 := upsertedAsset
-			ast2.RefreshedAt = &refreshedAtTime
+			ast2 := ast
+			ast2.RefreshedAt = nil
 			ast2.Description = "create a new version" // to force fetch from asset_versions.
 			_, err = r.repository.Upsert(r.ctx, &ast2)
 			r.NoError(err)
-			r.Greater(ast2.UpdatedAt.UnixNano(), upsertedAsset.UpdatedAt.UnixNano())
-			assetv1, err := r.repository.GetByVersionWithID(r.ctx, upsertedAsset.ID, asset.BaseVersion)
+			r.Greater(ast2.UpdatedAt.UnixNano(), ast.UpdatedAt.UnixNano())
+			assetv1, err := r.repository.GetByVersionWithID(r.ctx, ast.ID, asset.BaseVersion)
 			r.NoError(err)
 			r.Equal("0.1", assetv1.Version)
 		})
 
 		r.Run("should store owners if any", func() {
 			ast := asset.Asset{
-				URN:     "urn-u-3",
+				URN:     uuid.NewString() + "urn-u-3",
 				Type:    "table",
 				Service: "bigquery",
 				Owners: []user.User{
@@ -1023,11 +1037,12 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				UpdatedBy: r.users[0],
 			}
 
-			upsertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+			id, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.Require().NotEmpty(upsertedAsset.ID)
+			r.Require().NotEmpty(id)
+			ast.ID = id
 
-			actual, err := r.repository.GetByID(r.ctx, upsertedAsset.ID)
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
 			r.NoError(err)
 
 			r.Len(actual.Owners, 2)
@@ -1037,7 +1052,7 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 
 		r.Run("should create owners as users if they do not exist yet", func() {
 			ast := asset.Asset{
-				URN:     "urn-u-3a",
+				URN:     uuid.NewString() + "urn-u-3a",
 				Type:    "table",
 				Service: "bigquery",
 				Owners: []user.User{
@@ -1048,11 +1063,11 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				UpdatedBy: r.users[0],
 			}
 
-			upsertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+			id, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset.ID)
+			r.NotEmpty(id)
 
-			actual, err := r.repository.GetByID(r.ctx, upsertedAsset.ID)
+			actual, err := r.repository.GetByID(r.ctx, id)
 			r.NoError(err)
 
 			r.Len(actual.Owners, 2)
@@ -1063,7 +1078,7 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 	r.Run("on update", func() {
 		r.Run("should not create nor updating the asset if asset is identical", func() {
 			ast := asset.Asset{
-				URN:         "urn-u-2",
+				URN:         uuid.NewString() + "urn-u-2",
 				Type:        "table",
 				Service:     "bigquery",
 				UpdatedBy:   r.users[0],
@@ -1072,22 +1087,24 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 			}
 			identicalAsset := ast
 
-			upsertedAsset1, err := r.repository.Upsert(r.ctx, &ast)
+			id, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset1.ID)
+			r.NotEmpty(id)
+			ast.ID = id
 
-			upsertedAsset2, err := r.repository.Upsert(r.ctx, &identicalAsset)
+			id, err = r.repository.Upsert(r.ctx, &identicalAsset)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset2.ID)
+			r.NotEmpty(id)
+			identicalAsset.ID = id
 
-			r.Equal(upsertedAsset1.ID, upsertedAsset2.ID)
-			r.Equal(upsertedAsset1.Version, upsertedAsset2.Version)
+			r.Equal(ast.ID, identicalAsset.ID)
+			r.Equal(ast.Version, identicalAsset.Version)
 		})
 
 		r.Run("should same asset version if asset only has different at RefreshedAt", func() {
 			oneDayAgoRefreshedAtTime := refreshedAtTime.AddDate(0, 0, -1)
 			ast := asset.Asset{
-				URN:         "urn-u-2",
+				URN:         uuid.NewString() + "urn-u-2",
 				Type:        "table",
 				Service:     "bigquery",
 				URL:         "https://sample-url-old.com",
@@ -1096,18 +1113,20 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				Version:     "0.1",
 			}
 
-			upsertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+			id, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset.ID)
+			r.NotEmpty(id)
+			ast.ID = id
 
-			updated := upsertedAsset
+			updated := ast
 			updated.RefreshedAt = &refreshedAtTime
 
-			upsertedAsset2, err := r.repository.Upsert(r.ctx, &updated)
+			id, err = r.repository.Upsert(r.ctx, &updated)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset2.ID)
+			r.NotEmpty(id)
+			updated.ID = id
 
-			r.Equal(upsertedAsset.ID, upsertedAsset2.ID)
+			r.Equal(ast.ID, updated.ID)
 
 			actual, err := r.repository.GetByID(r.ctx, ast.ID)
 			r.NoError(err)
@@ -1118,7 +1137,7 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 
 		r.Run("should update the asset version if asset is not identical", func() {
 			ast := asset.Asset{
-				URN:       "urn-u-2",
+				URN:       uuid.NewString() + "urn-u-2",
 				Type:      "table",
 				Service:   "bigquery",
 				URL:       "https://sample-url-old.com",
@@ -1126,20 +1145,22 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				Version:   "0.1",
 			}
 
-			upsertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+			id, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset.ID)
+			r.NotEmpty(id)
+			ast.ID = id
 
-			updated := upsertedAsset
+			updated := ast
 			updated.URL = "https://sample-url.com"
 
-			upsertedAsset2, err := r.repository.Upsert(r.ctx, &updated)
+			id, err = r.repository.Upsert(r.ctx, &updated)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset2.ID)
+			r.NotEmpty(id)
+			updated.ID = id
 
-			r.Equal(upsertedAsset.ID, upsertedAsset2.ID)
+			r.Equal(ast.ID, updated.ID)
 
-			actual, err := r.repository.GetByID(r.ctx, upsertedAsset.ID)
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
 			r.NoError(err)
 
 			r.Equal(updated.URL, actual.URL)
@@ -1148,7 +1169,7 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 
 		r.Run("should delete old owners if it does not exist on new asset", func() {
 			ast := asset.Asset{
-				URN:     "urn-u-4",
+				URN:     uuid.NewString() + "urn-u-4",
 				Type:    "table",
 				Service: "bigquery",
 				Owners: []user.User{
@@ -1162,21 +1183,25 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				stripUserID(r.users[2]),
 			}
 
-			upsertedAsset1, err := r.repository.Upsert(r.ctx, &ast)
+			id, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset1.ID)
+			r.NotEmpty(id)
+			ast.ID = id
 
-			upsertedAsset2, err := r.repository.Upsert(r.ctx, &newAsset)
+			id, err = r.repository.Upsert(r.ctx, &newAsset)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset2.ID)
+			r.NotEmpty(id)
+			newAsset.ID = id
 
-			r.Len(upsertedAsset1.Owners, len(upsertedAsset2.Owners))
-			r.Equal(r.users[2].ID, upsertedAsset1.Owners[0].ID)
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
+			r.NoError(err)
+			r.Len(actual.Owners, len(newAsset.Owners))
+			r.Equal(r.users[2].ID, actual.Owners[0].ID)
 		})
 
 		r.Run("should create new owners if it does not exist on old asset", func() {
 			ast := asset.Asset{
-				URN:     "urn-u-4",
+				URN:     uuid.NewString() + "urn-u-4",
 				Type:    "table",
 				Service: "bigquery",
 				Owners: []user.User{
@@ -1190,22 +1215,26 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				stripUserID(r.users[2]),
 			}
 
-			upsertedAsset1, err := r.repository.Upsert(r.ctx, &ast)
+			id, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset1.ID)
+			r.NotEmpty(id)
+			ast.ID = id
 
-			upsertedAsset2, err := r.repository.Upsert(r.ctx, &newAsset)
+			id, err = r.repository.Upsert(r.ctx, &newAsset)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset2.ID)
+			r.NotEmpty(id)
+			newAsset.ID = id
 
-			r.Len(upsertedAsset1.Owners, len(upsertedAsset2.Owners))
-			r.Equal(r.users[1].ID, upsertedAsset1.Owners[0].ID)
-			r.Equal(r.users[2].ID, upsertedAsset1.Owners[1].ID)
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
+			r.NoError(err)
+			r.Len(actual.Owners, len(newAsset.Owners))
+			r.Equal(r.users[1].ID, actual.Owners[0].ID)
+			r.Equal(r.users[2].ID, actual.Owners[1].ID)
 		})
 
 		r.Run("should create users from owners if owner emails do not exist yet", func() {
 			ast := asset.Asset{
-				URN:     "urn-u-4a",
+				URN:     uuid.NewString() + "urn-u-4a",
 				Type:    "table",
 				Service: "bigquery",
 				Owners: []user.User{
@@ -1219,19 +1248,23 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				{Email: "newuser@example.com"},
 			}
 
-			upsertedAsset1, err := r.repository.Upsert(r.ctx, &ast)
+			id, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset1.ID)
+			r.NotEmpty(id)
+			ast.ID = id
 
-			upsertedAsset2, err := r.repository.Upsert(r.ctx, &newAsset)
+			id, err = r.repository.Upsert(r.ctx, &newAsset)
 			r.Require().NoError(err)
-			r.NotEmpty(upsertedAsset2.ID)
+			r.NotEmpty(id)
+			newAsset.ID = id
 
-			r.Len(upsertedAsset1.Owners, len(upsertedAsset2.Owners))
-			r.NotEmpty(upsertedAsset1.Owners[0].ID)
-			r.Equal(r.users[1].ID, upsertedAsset1.Owners[0].ID)
-			r.NotEmpty(upsertedAsset1.Owners[1].ID)
-			r.Equal(upsertedAsset2.Owners[1].Email, upsertedAsset1.Owners[1].Email)
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
+			r.NoError(err)
+			r.Len(actual.Owners, len(newAsset.Owners))
+			r.NotEmpty(actual.Owners[0].ID)
+			r.Equal(r.users[1].ID, actual.Owners[0].ID)
+			r.NotEmpty(actual.Owners[1].ID)
+			r.Equal(newAsset.Owners[1].Email, actual.Owners[1].Email)
 		})
 	})
 }
@@ -1239,7 +1272,7 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 func (r *AssetRepositoryTestSuite) TestUpsertRaceCondition() {
 	r.Run("TestUpsertRaceCondition", func() {
 		ast := asset.Asset{
-			URN:       "urn-u-3",
+			URN:       "urn-upsert-race-condition",
 			Type:      "table",
 			Service:   "bigquery",
 			URL:       "https://sample-url-old.com",
@@ -1247,9 +1280,9 @@ func (r *AssetRepositoryTestSuite) TestUpsertRaceCondition() {
 			Version:   "0.1",
 		}
 
-		upsertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+		id, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.NotEmpty(upsertedAsset.ID)
+		r.NotEmpty(id)
 
 		const numGoroutines = 10 // Number of concurrent upserts
 		var wg sync.WaitGroup
@@ -1265,6 +1298,476 @@ func (r *AssetRepositoryTestSuite) TestUpsertRaceCondition() {
 				localAst := ast
 				localAst.URL = fmt.Sprintf("https://sample-url-%d.com", index)
 				_, err := r.repository.Upsert(context.Background(), &localAst)
+
+				mu.Lock()
+				results = append(results, err)
+				mu.Unlock()
+			}(i)
+		}
+
+		wg.Wait()
+
+		// Check for errors
+		for _, err := range results {
+			assert.NoError(r.T(), err, "Upsert should not fail under race conditions")
+		}
+	})
+}
+
+func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
+	refreshedAtTime := time.Date(2024, time.August, 20, 8, 19, 49, 0, time.UTC)
+	r.Run("on insert", func() {
+		r.Run("should do nothing for patch data on insert action", func() {
+			ast := asset.Asset{
+				URN:     "urn-i-0",
+				Name:    "urn-test",
+				Type:    "table",
+				Service: "bigquery",
+				Owners: []user.User{
+					r.users[1],
+				},
+				Data: map[string]interface{}{
+					"entity": "gojek",
+				},
+				UpdatedBy: r.users[0],
+			}
+
+			patchData := make(map[string]interface{})
+			patchData["data"] = map[string]interface{}{
+				"entity": "gotocompany",
+			}
+
+			id, err := r.repository.UpsertPatch(r.ctx, &ast, patchData)
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+
+			actual, err := r.repository.GetByID(r.ctx, id)
+			r.NoError(err)
+			r.NotEqual(actual.Data["entity"], "gotocompany")
+			r.Equal(actual.Data["entity"], "gojek")
+		})
+
+		r.Run("set ID to asset and version to base version", func() {
+			ast := asset.Asset{
+				URN:     "urn-i-1",
+				Name:    "urn-test",
+				Type:    "table",
+				Service: "bigquery",
+				URL:     "https://sample-url.com",
+				Data: map[string]interface{}{
+					"entity": "gojek",
+				},
+				UpdatedBy:   r.users[0],
+				RefreshedAt: &refreshedAtTime,
+			}
+
+			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+			r.Equal(asset.BaseVersion, ast.Version)
+			r.NoError(err)
+			r.NotEmpty(id)
+			r.NotEmpty(ast.CreatedAt)
+			r.NotEmpty(ast.UpdatedAt)
+			ast.ID = id
+
+			assetInDB, err := r.repository.GetByID(r.ctx, ast.ID)
+			r.Require().NoError(err)
+			r.NotEqual(time.Time{}, assetInDB.CreatedAt)
+			r.NotEqual(time.Time{}, assetInDB.UpdatedAt)
+			r.assertAsset(&ast, &assetInDB)
+
+			ast2 := ast
+			ast2.RefreshedAt = nil
+			ast2.Description = "create a new version" // to force fetch from asset_versions.
+			_, err = r.repository.UpsertPatch(r.ctx, &ast2, nil)
+			r.NoError(err)
+			r.Greater(ast2.UpdatedAt.UnixNano(), ast.UpdatedAt.UnixNano())
+			assetv1, err := r.repository.GetByVersionWithID(r.ctx, ast.ID, asset.BaseVersion)
+			r.NoError(err)
+			r.Equal("0.1", assetv1.Version)
+		})
+
+		r.Run("should store owners if any", func() {
+			ast := asset.Asset{
+				URN:     "urn-i-3",
+				Name:    "urn-test",
+				Type:    "table",
+				Service: "bigquery",
+				Owners: []user.User{
+					r.users[1],
+					{Email: r.users[2].Email},
+					{ID: r.users[1].ID}, // should get deduplicated by ID
+				},
+				Data: map[string]interface{}{
+					"entity": "gojek",
+				},
+				UpdatedBy: r.users[0],
+			}
+
+			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+			r.Require().NoError(err)
+			r.Require().NotEmpty(id)
+			ast.ID = id
+
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
+			r.NoError(err)
+
+			r.Len(actual.Owners, 2)
+			r.Equal(r.users[1].ID, actual.Owners[0].ID)
+			r.Equal(r.users[2].ID, actual.Owners[1].ID)
+		})
+
+		r.Run("should create owners as users if they do not exist yet", func() {
+			ast := asset.Asset{
+				URN:     "urn-i-patch-insert-create-owner",
+				Name:    "urn-test",
+				Type:    "table",
+				Service: "bigquery",
+				Owners: []user.User{
+					{Email: "newuserpatch@example.com"},
+					{Email: "newuserpatch2@example.com"},
+					{Email: "newuserpatch@example.com"}, // should get deduplicated by ID on fetch user by email
+				},
+				Data: map[string]interface{}{
+					"entity": "gojek",
+				},
+				UpdatedBy: r.users[0],
+			}
+
+			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+
+			actual, err := r.repository.GetByID(r.ctx, id)
+			r.NoError(err)
+
+			r.Len(actual.Owners, 2)
+			r.Equal(ast.Owners[0].Email, actual.Owners[0].Email)
+		})
+	})
+
+	r.Run("on update", func() {
+		r.Run("should not create nor updating the asset if asset is identical", func() {
+			ast := asset.Asset{
+				URN:     uuid.NewString() + "urn-u-2",
+				Name:    "urn-test",
+				Type:    "table",
+				Service: "bigquery",
+				Data: map[string]interface{}{
+					"entity": "gotocompany",
+				},
+				UpdatedBy:   r.users[0],
+				RefreshedAt: &refreshedAtTime,
+				Version:     "0.1",
+			}
+			identicalAsset := ast
+
+			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+			ast.ID = id
+
+			patchData := make(map[string]interface{})
+			patchData["data"] = map[string]interface{}{
+				"entity": "gotocompany",
+			}
+
+			id, err = r.repository.UpsertPatch(r.ctx, &identicalAsset, patchData) // update
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+			identicalAsset.ID = id
+
+			r.Equal(ast.ID, identicalAsset.ID)
+			r.Equal(ast.Version, identicalAsset.Version)
+			r.Equal(identicalAsset.Data["entity"], "gotocompany")
+		})
+
+		r.Run("should same asset version if asset only has different at RefreshedAt", func() {
+			oneDayAgoRefreshedAtTime := refreshedAtTime.AddDate(0, 0, -1)
+			ast := asset.Asset{
+				URN:     uuid.NewString() + "urn-u-2",
+				Name:    "urn-test",
+				Type:    "table",
+				Service: "bigquery",
+				URL:     "https://sample-url-old.com",
+				Data: map[string]interface{}{
+					"entity": "gotocompany",
+				},
+				UpdatedBy:   r.users[0],
+				RefreshedAt: &oneDayAgoRefreshedAtTime,
+				Version:     "0.1",
+			}
+
+			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+			ast.ID = id
+
+			updated := ast
+			updated.RefreshedAt = &refreshedAtTime
+			patchData := make(map[string]interface{})
+			patchData["data"] = map[string]interface{}{
+				"entity": "gotocompany",
+			}
+
+			id, err = r.repository.UpsertPatch(r.ctx, &updated, patchData) // update
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+			updated.ID = id
+
+			r.Equal(ast.ID, updated.ID)
+
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
+			r.NoError(err)
+
+			r.Equal(updated.RefreshedAt, actual.RefreshedAt)
+			r.Equal(ast.Version, actual.Version)
+			r.Equal(actual.Data["entity"], "gotocompany")
+		})
+
+		r.Run("should update the asset version if asset is not identical", func() {
+			ast := asset.Asset{
+				URN:     uuid.NewString() + "urn-u-2",
+				Name:    "urn-test",
+				Type:    "table",
+				Service: "bigquery",
+				URL:     "https://sample-url-old.com",
+				Data: map[string]interface{}{
+					"entity": "gotocompany",
+				},
+				UpdatedBy: r.users[0],
+				Version:   "0.1",
+			}
+
+			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+			ast.ID = id
+
+			updated := ast
+			patchData := make(map[string]interface{})
+			patchData["url"] = "https://sample-url.com"
+
+			id, err = r.repository.UpsertPatch(r.ctx, &updated, patchData) // update
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+			updated.ID = id
+
+			r.Equal(ast.ID, updated.ID)
+
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
+			r.NoError(err)
+
+			r.Equal(updated.URL, actual.URL)
+			r.NotEqual(ast.Version, actual.Version)
+		})
+
+		r.Run("should keep old data if it does not exist on new asset", func() {
+			ast := asset.Asset{
+				URN:     uuid.NewString() + "urn-u-4",
+				Name:    "urn-test",
+				Type:    "table",
+				Service: "bigquery",
+				Owners: []user.User{
+					stripUserID(r.users[1]),
+				},
+				Data: map[string]interface{}{
+					"entity": "gotocompany",
+				},
+				UpdatedBy: r.users[0],
+			}
+			newAsset := ast
+			newAsset.Owners = []user.User{
+				stripUserID(r.users[2]),
+			}
+
+			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+
+			patchData := make(map[string]interface{})
+			patchData["data"] = map[string]interface{}{
+				"another": "things",
+			}
+
+			id, err = r.repository.UpsertPatch(r.ctx, &newAsset, patchData) // update
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
+			r.NoError(err)
+			r.Len(actual.Data, 2)
+			r.Equal(actual.Data["entity"], "gotocompany")
+			r.Equal(actual.Data["another"], "things")
+		})
+
+		r.Run("should delete old owners if it does not exist on new patch", func() {
+			ast := asset.Asset{
+				URN:     uuid.NewString() + "urn-u-4",
+				Name:    "urn-test",
+				Type:    "table",
+				Service: "bigquery",
+				Owners: []user.User{
+					stripUserID(r.users[1]),
+				},
+				Data: map[string]interface{}{
+					"entity": "gotocompany",
+				},
+				UpdatedBy: r.users[0],
+			}
+			newAsset := ast
+
+			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+			ast.ID = id
+
+			patchData := make(map[string]interface{})
+			patchData["owners"] = []map[string]interface{}{
+				{
+					"id":       r.users[2].ID,
+					"email":    r.users[2].Email,
+					"provider": r.users[2].Provider,
+				},
+			}
+
+			id, err = r.repository.UpsertPatch(r.ctx, &newAsset, patchData)
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
+			r.NoError(err)
+			r.Len(actual.Owners, len(newAsset.Owners))
+			r.Equal(r.users[2].ID, actual.Owners[0].ID)
+		})
+
+		r.Run("should create new owners if it does not exist on old asset", func() {
+			ast := asset.Asset{
+				URN:     uuid.NewString() + "urn-u-4",
+				Name:    "urn-test",
+				Type:    "table",
+				Service: "bigquery",
+				Owners: []user.User{
+					stripUserID(r.users[1]),
+				},
+				Data: map[string]interface{}{
+					"entity": "gotocompany",
+				},
+				UpdatedBy: r.users[0],
+			}
+			newAsset := ast
+
+			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+
+			patchData := make(map[string]interface{})
+			patchData["owners"] = []map[string]interface{}{
+				{
+					"id":       r.users[1].ID,
+					"email":    r.users[1].Email,
+					"provider": r.users[1].Provider,
+				},
+				{
+					"id":       r.users[2].ID,
+					"email":    r.users[2].Email,
+					"provider": r.users[2].Provider,
+				},
+			}
+
+			id, err = r.repository.UpsertPatch(r.ctx, &newAsset, patchData)
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
+			r.NoError(err)
+			r.Len(actual.Owners, len(newAsset.Owners))
+			r.Equal(r.users[1].ID, actual.Owners[0].ID)
+			r.Equal(r.users[2].ID, actual.Owners[1].ID)
+		})
+
+		r.Run("should create users from owners if owner emails do not exist yet", func() {
+			ast := asset.Asset{
+				URN:     uuid.NewString() + "urn-u-4a",
+				Name:    "urn-test",
+				Type:    "table",
+				Service: "bigquery",
+				Owners: []user.User{
+					stripUserID(r.users[1]),
+				},
+				Data: map[string]interface{}{
+					"entity": "gotocompany",
+				},
+				UpdatedBy: r.users[0],
+			}
+			newAsset := ast
+
+			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+
+			patchData := make(map[string]interface{})
+			patchData["owners"] = []map[string]interface{}{
+				{
+					"id":       r.users[1].ID,
+					"email":    r.users[1].Email,
+					"provider": r.users[1].Provider,
+				},
+				{
+					"email": "newuser@example.com",
+				},
+			}
+
+			id, err = r.repository.UpsertPatch(r.ctx, &newAsset, patchData) // update
+			r.Require().NoError(err)
+			r.NotEmpty(id)
+
+			actual, err := r.repository.GetByID(r.ctx, ast.ID)
+			r.NoError(err)
+			r.Len(actual.Owners, len(newAsset.Owners))
+			r.NotEmpty(actual.Owners[0].ID)
+			r.Equal(r.users[1].ID, actual.Owners[0].ID)
+			r.NotEmpty(actual.Owners[1].ID)
+			r.Equal(newAsset.Owners[1].Email, actual.Owners[1].Email)
+		})
+	})
+}
+
+func (r *AssetRepositoryTestSuite) TestUpsertPatchRaceCondition() {
+	r.Run("TestUpsertPatchRaceCondition", func() {
+		ast := asset.Asset{
+			URN:     "urn-upsert-patch-race-condition",
+			Name:    "urn-test",
+			Type:    "table",
+			Service: "bigquery",
+			URL:     "https://sample-url-old.com",
+			Data: map[string]interface{}{
+				"entity": "gotocompany",
+			},
+			UpdatedBy: r.users[0],
+			Version:   "0.1",
+		}
+
+		id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+		r.Require().NoError(err)
+		r.NotEmpty(id)
+
+		const numGoroutines = 10 // Number of concurrent upserts
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		results := make([]error, 0, numGoroutines)
+
+		// Concurrently upsert the object
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func(index int) {
+				defer wg.Done()
+
+				localAst := ast
+				patchData := make(map[string]interface{})
+				patchData["data"] = map[string]interface{}{
+					"entity": fmt.Sprintf("entity-%d", index),
+				}
+				_, err := r.repository.UpsertPatch(context.Background(), &localAst, patchData)
 
 				mu.Lock()
 				results = append(results, err)
@@ -1310,26 +1813,28 @@ func (r *AssetRepositoryTestSuite) TestDeleteByID() {
 		}
 
 		var err error
-		upsertedAsset1, err := r.repository.Upsert(r.ctx, &asset1)
+		id, err := r.repository.Upsert(r.ctx, &asset1)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(upsertedAsset1.ID)
+		r.Require().NotEmpty(id)
+		asset1.ID = id
 
-		upsertedAsset2, err := r.repository.Upsert(r.ctx, &asset2)
+		id, err = r.repository.Upsert(r.ctx, &asset2)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(upsertedAsset2.ID)
+		r.Require().NotEmpty(id)
+		asset2.ID = id
 
-		err = r.repository.DeleteByID(r.ctx, upsertedAsset1.ID)
+		err = r.repository.DeleteByID(r.ctx, asset1.ID)
 		r.NoError(err)
 
-		_, err = r.repository.GetByID(r.ctx, upsertedAsset1.ID)
-		r.ErrorAs(err, &asset.NotFoundError{AssetID: upsertedAsset1.ID})
+		_, err = r.repository.GetByID(r.ctx, asset1.ID)
+		r.ErrorAs(err, &asset.NotFoundError{AssetID: asset1.ID})
 
-		asset2FromDB, err := r.repository.GetByID(r.ctx, upsertedAsset2.ID)
+		asset2FromDB, err := r.repository.GetByID(r.ctx, asset2.ID)
 		r.NoError(err)
-		r.Equal(upsertedAsset2.ID, asset2FromDB.ID)
+		r.Equal(asset2.ID, asset2FromDB.ID)
 
 		// cleanup
-		err = r.repository.DeleteByID(r.ctx, upsertedAsset2.ID)
+		err = r.repository.DeleteByID(r.ctx, asset2.ID)
 		r.NoError(err)
 	})
 }

--- a/internal/store/postgres/asset_repository_test.go
+++ b/internal/store/postgres/asset_repository_test.go
@@ -87,7 +87,7 @@ func (r *AssetRepositoryTestSuite) createUsers(userRepo user.Repository) []user.
 	return users
 }
 
-func (r *AssetRepositoryTestSuite) BeforeTest(suiteName, testName string) {
+func (r *AssetRepositoryTestSuite) BeforeTest(_, _ string) {
 	err := testutils.RunMigrationsWithClient(r.T(), r.client)
 	r.NoError(err)
 

--- a/internal/store/postgres/asset_repository_test.go
+++ b/internal/store/postgres/asset_repository_test.go
@@ -87,7 +87,7 @@ func (r *AssetRepositoryTestSuite) createUsers(userRepo user.Repository) []user.
 	return users
 }
 
-func (r *AssetRepositoryTestSuite) BeforeTest() {
+func (r *AssetRepositoryTestSuite) BeforeTest(suiteName, testName string) {
 	err := testutils.RunMigrationsWithClient(r.T(), r.client)
 	r.NoError(err)
 
@@ -607,18 +607,17 @@ func (r *AssetRepositoryTestSuite) TestGetByID() {
 		}
 
 		var err error
-		upsertedAsset, err := r.repository.Upsert(r.ctx, &asset1)
+		upsertedAsset1, err := r.repository.Upsert(r.ctx, &asset1)
 		r.Require().NoError(err)
-		r.NotEmpty(upsertedAsset.ID)
+		r.NotEmpty(upsertedAsset1.ID)
 
-		upsertedAsset, err = r.repository.Upsert(r.ctx, &asset2)
+		upsertedAsset2, err := r.repository.Upsert(r.ctx, &asset2)
 		r.Require().NoError(err)
-		r.NotEmpty(upsertedAsset.ID)
+		r.NotEmpty(upsertedAsset2.ID)
 
-		result, err := r.repository.GetByID(r.ctx, asset2.ID)
+		result, err := r.repository.GetByID(r.ctx, upsertedAsset2.ID)
 		r.NoError(err)
-		asset2.UpdatedBy = r.users[1]
-		r.assertAsset(&asset2, &result)
+		r.assertAsset(&upsertedAsset2, &result)
 	})
 
 	r.Run("return owners if any", func() {
@@ -637,10 +636,8 @@ func (r *AssetRepositoryTestSuite) TestGetByID() {
 		r.Require().NoError(err)
 		r.Require().NotEmpty(upsertedAsset.ID)
 
-		result, err := r.repository.GetByID(r.ctx, ast.ID)
-		r.NoError(err)
-		r.Len(result.Owners, len(ast.Owners))
-		for i, owner := range result.Owners {
+		r.Len(upsertedAsset.Owners, len(ast.Owners))
+		for i, owner := range upsertedAsset.Owners {
 			r.Equal(ast.Owners[i].ID, owner.ID)
 		}
 	})
@@ -1471,7 +1468,7 @@ func (r *AssetRepositoryTestSuite) TestAddProbe() {
 	})
 
 	r.Run("should populate CreatedAt and persist probe", func() {
-		r.BeforeTest()
+		r.BeforeTest("", "")
 		ast := asset.Asset{
 			URN:       "urn-add-probe-1",
 			Type:      typeJob,

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -42,11 +42,7 @@ type Client struct {
 }
 
 func (c *Client) RunWithinTx(ctx context.Context, f func(tx *sqlx.Tx) error) error {
-	return c.RunWithinTxWithOption(ctx, nil, f)
-}
-
-func (c *Client) RunWithinTxWithOption(ctx context.Context, opts *sql.TxOptions, f func(tx *sqlx.Tx) error) error {
-	tx, err := c.db.BeginTxx(ctx, opts)
+	tx, err := c.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("starting transaction: %w", err)
 	}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -42,7 +42,11 @@ type Client struct {
 }
 
 func (c *Client) RunWithinTx(ctx context.Context, f func(tx *sqlx.Tx) error) error {
-	tx, err := c.db.BeginTxx(ctx, nil)
+	return c.RunWithinTxWithOption(ctx, nil, f)
+}
+
+func (c *Client) RunWithinTxWithOption(ctx context.Context, opts *sql.TxOptions, f func(tx *sqlx.Tx) error) error {
+	tx, err := c.db.BeginTxx(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("starting transaction: %w", err)
 	}

--- a/internal/store/postgres/postgres_test.go
+++ b/internal/store/postgres/postgres_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	logLevelDebug       = "debug"
 	defaultProviderName = "shield"
 	defaultGetMaxSize   = 7
 )
@@ -54,8 +53,8 @@ func newTestClient(t *testing.T, logger log.Logger) (*postgres.Client, error) {
 
 // helper functions
 func createUser(userRepo user.Repository, email string) (string, error) {
-	user := getUser(email)
-	id, err := userRepo.Create(context.Background(), user)
+	userTest := getUser(email)
+	id, err := userRepo.Create(context.Background(), userTest)
 	if err != nil {
 		return "", err
 	}
@@ -65,12 +64,11 @@ func createUser(userRepo user.Repository, email string) (string, error) {
 func createAsset(assetRepo asset.Repository, updaterID, ownerEmail, assetURN, assetType string) (*asset.Asset, error) {
 	ast := getAsset(ownerEmail, assetURN, assetType)
 	ast.UpdatedBy.ID = updaterID
-	id, err := assetRepo.Upsert(context.Background(), ast)
+	upsertedAsset, err := assetRepo.Upsert(context.Background(), ast)
 	if err != nil {
 		return nil, err
 	}
-	ast.ID = id
-	return ast, nil
+	return &upsertedAsset, nil
 }
 
 func getAsset(ownerEmail, assetURN, assetType string) *asset.Asset {

--- a/internal/store/postgres/postgres_test.go
+++ b/internal/store/postgres/postgres_test.go
@@ -64,11 +64,12 @@ func createUser(userRepo user.Repository, email string) (string, error) {
 func createAsset(assetRepo asset.Repository, updaterID, ownerEmail, assetURN, assetType string) (*asset.Asset, error) {
 	ast := getAsset(ownerEmail, assetURN, assetType)
 	ast.UpdatedBy.ID = updaterID
-	upsertedAsset, err := assetRepo.Upsert(context.Background(), ast)
+	id, err := assetRepo.Upsert(context.Background(), ast)
 	if err != nil {
 		return nil, err
 	}
-	return &upsertedAsset, nil
+	ast.ID = id
+	return ast, nil
 }
 
 func getAsset(ownerEmail, assetURN, assetType string) *asset.Asset {


### PR DESCRIPTION
When some jobs that has same recipe run at the same time, it makes those assets has the `version` in `assets_versions` table greater than `version` in `assets` table. This is not expected because `version` in `assets` table should be the (new) highest number, so should be equals to highest number of the `version` in `assets_versions` . The expectation is with transaction sql (the race condition should be handled), it will insert new rows in assets_version with increasing minor version (exp: 0.9 → 0.10) IF ONLY there is an update on the job AND has the changelog.

For example bug case:
- asset_test_a in assets table has version 0.99
- The highest version for asset_test_a in assets_versions table has version 0.100
- When update the assets and has change log, it will raise error duplicate key value violates unique constraint \"assets_versions_idx_asset_id_version\" since combination asset_test_a ID and 0.100 already exist


**The solution:**
Using Row-level Locks (ref: https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-ROWS) with SELECT FOR UPDATE within same one transaction for both select and update