### PR TITLE
fix: sync all asset data to elasticsearch on upsert patch API

### DIFF
--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -20,8 +20,8 @@ type Repository interface {
 	GetByVersionWithID(ctx context.Context, id, version string) (Asset, error)
 	GetByVersionWithURN(ctx context.Context, urn, version string) (Asset, error)
 	GetTypes(ctx context.Context, flt Filter) (map[Type]int, error)
-	Upsert(ctx context.Context, ast *Asset) (string, error)
-	UpsertPatch(ctx context.Context, ast *Asset, patchData map[string]interface{}) (string, error)
+	Upsert(ctx context.Context, ast *Asset) (Asset, error)
+	UpsertPatch(ctx context.Context, ast *Asset, patchData map[string]interface{}) (Asset, error)
 	DeleteByID(ctx context.Context, id string) error
 	DeleteByURN(ctx context.Context, urn string) error
 	DeleteByQueryExpr(ctx context.Context, queryExpr queryexpr.ExprStr) ([]string, error)

--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -20,8 +20,8 @@ type Repository interface {
 	GetByVersionWithID(ctx context.Context, id, version string) (Asset, error)
 	GetByVersionWithURN(ctx context.Context, urn, version string) (Asset, error)
 	GetTypes(ctx context.Context, flt Filter) (map[Type]int, error)
-	Upsert(ctx context.Context, ast *Asset) (Asset, error)
-	UpsertPatch(ctx context.Context, ast *Asset, patchData map[string]interface{}) (Asset, error)
+	Upsert(ctx context.Context, ast *Asset) (*Asset, error)
+	UpsertPatch(ctx context.Context, ast *Asset, patchData map[string]interface{}) (*Asset, error)
 	DeleteByID(ctx context.Context, id string) error
 	DeleteByURN(ctx context.Context, urn string) error
 	DeleteByQueryExpr(ctx context.Context, queryExpr queryexpr.ExprStr) ([]string, error)

--- a/core/asset/mocks/asset_repository.go
+++ b/core/asset/mocks/asset_repository.go
@@ -807,18 +807,18 @@ func (_c *AssetRepository_GetVersionHistory_Call) RunAndReturn(run func(context.
 }
 
 // Upsert provides a mock function with given fields: ctx, ast
-func (_m *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (string, error) {
+func (_m *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (asset.Asset, error) {
 	ret := _m.Called(ctx, ast)
 
-	var r0 string
+	var r0 asset.Asset
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) (string, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) (asset.Asset, error)); ok {
 		return rf(ctx, ast)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) string); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) asset.Asset); ok {
 		r0 = rf(ctx, ast)
 	} else {
-		r0 = ret.Get(0).(string)
+		r0 = ret.Get(0).(asset.Asset)
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *asset.Asset) error); ok {
@@ -849,29 +849,29 @@ func (_c *AssetRepository_Upsert_Call) Run(run func(ctx context.Context, ast *as
 	return _c
 }
 
-func (_c *AssetRepository_Upsert_Call) Return(_a0 string, _a1 error) *AssetRepository_Upsert_Call {
+func (_c *AssetRepository_Upsert_Call) Return(_a0 asset.Asset, _a1 error) *AssetRepository_Upsert_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AssetRepository_Upsert_Call) RunAndReturn(run func(context.Context, *asset.Asset) (string, error)) *AssetRepository_Upsert_Call {
+func (_c *AssetRepository_Upsert_Call) RunAndReturn(run func(context.Context, *asset.Asset) (asset.Asset, error)) *AssetRepository_Upsert_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpsertPatch provides a mock function with given fields: ctx, ast, patchData
-func (_m *AssetRepository) UpsertPatch(ctx context.Context, ast *asset.Asset, patchData map[string]interface{}) (string, error) {
+func (_m *AssetRepository) UpsertPatch(ctx context.Context, ast *asset.Asset, patchData map[string]interface{}) (asset.Asset, error) {
 	ret := _m.Called(ctx, ast, patchData)
 
-	var r0 string
+	var r0 asset.Asset
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) (string, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) (asset.Asset, error)); ok {
 		return rf(ctx, ast, patchData)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) string); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) asset.Asset); ok {
 		r0 = rf(ctx, ast, patchData)
 	} else {
-		r0 = ret.Get(0).(string)
+		r0 = ret.Get(0).(asset.Asset)
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *asset.Asset, map[string]interface{}) error); ok {
@@ -903,12 +903,12 @@ func (_c *AssetRepository_UpsertPatch_Call) Run(run func(ctx context.Context, as
 	return _c
 }
 
-func (_c *AssetRepository_UpsertPatch_Call) Return(_a0 string, _a1 error) *AssetRepository_UpsertPatch_Call {
+func (_c *AssetRepository_UpsertPatch_Call) Return(_a0 asset.Asset, _a1 error) *AssetRepository_UpsertPatch_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AssetRepository_UpsertPatch_Call) RunAndReturn(run func(context.Context, *asset.Asset, map[string]interface{}) (string, error)) *AssetRepository_UpsertPatch_Call {
+func (_c *AssetRepository_UpsertPatch_Call) RunAndReturn(run func(context.Context, *asset.Asset, map[string]interface{}) (asset.Asset, error)) *AssetRepository_UpsertPatch_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/asset/mocks/asset_repository.go
+++ b/core/asset/mocks/asset_repository.go
@@ -807,18 +807,20 @@ func (_c *AssetRepository_GetVersionHistory_Call) RunAndReturn(run func(context.
 }
 
 // Upsert provides a mock function with given fields: ctx, ast
-func (_m *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (asset.Asset, error) {
+func (_m *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (*asset.Asset, error) {
 	ret := _m.Called(ctx, ast)
 
-	var r0 asset.Asset
+	var r0 *asset.Asset
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) (asset.Asset, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) (*asset.Asset, error)); ok {
 		return rf(ctx, ast)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) asset.Asset); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset) *asset.Asset); ok {
 		r0 = rf(ctx, ast)
 	} else {
-		r0 = ret.Get(0).(asset.Asset)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*asset.Asset)
+		}
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *asset.Asset) error); ok {
@@ -849,29 +851,31 @@ func (_c *AssetRepository_Upsert_Call) Run(run func(ctx context.Context, ast *as
 	return _c
 }
 
-func (_c *AssetRepository_Upsert_Call) Return(_a0 asset.Asset, _a1 error) *AssetRepository_Upsert_Call {
+func (_c *AssetRepository_Upsert_Call) Return(_a0 *asset.Asset, _a1 error) *AssetRepository_Upsert_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AssetRepository_Upsert_Call) RunAndReturn(run func(context.Context, *asset.Asset) (asset.Asset, error)) *AssetRepository_Upsert_Call {
+func (_c *AssetRepository_Upsert_Call) RunAndReturn(run func(context.Context, *asset.Asset) (*asset.Asset, error)) *AssetRepository_Upsert_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpsertPatch provides a mock function with given fields: ctx, ast, patchData
-func (_m *AssetRepository) UpsertPatch(ctx context.Context, ast *asset.Asset, patchData map[string]interface{}) (asset.Asset, error) {
+func (_m *AssetRepository) UpsertPatch(ctx context.Context, ast *asset.Asset, patchData map[string]interface{}) (*asset.Asset, error) {
 	ret := _m.Called(ctx, ast, patchData)
 
-	var r0 asset.Asset
+	var r0 *asset.Asset
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) (asset.Asset, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) (*asset.Asset, error)); ok {
 		return rf(ctx, ast, patchData)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) asset.Asset); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *asset.Asset, map[string]interface{}) *asset.Asset); ok {
 		r0 = rf(ctx, ast, patchData)
 	} else {
-		r0 = ret.Get(0).(asset.Asset)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*asset.Asset)
+		}
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *asset.Asset, map[string]interface{}) error); ok {
@@ -903,12 +907,12 @@ func (_c *AssetRepository_UpsertPatch_Call) Run(run func(ctx context.Context, as
 	return _c
 }
 
-func (_c *AssetRepository_UpsertPatch_Call) Return(_a0 asset.Asset, _a1 error) *AssetRepository_UpsertPatch_Call {
+func (_c *AssetRepository_UpsertPatch_Call) Return(_a0 *asset.Asset, _a1 error) *AssetRepository_UpsertPatch_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *AssetRepository_UpsertPatch_Call) RunAndReturn(run func(context.Context, *asset.Asset, map[string]interface{}) (asset.Asset, error)) *AssetRepository_UpsertPatch_Call {
+func (_c *AssetRepository_UpsertPatch_Call) RunAndReturn(run func(context.Context, *asset.Asset, map[string]interface{}) (*asset.Asset, error)) *AssetRepository_UpsertPatch_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/asset/service.go
+++ b/core/asset/service.go
@@ -107,21 +107,20 @@ func (s *Service) UpsertAssetWithoutLineage(ctx context.Context, ast *Asset) (st
 	currentTime := time.Now()
 	ast.RefreshedAt = &currentTime
 
-	assetID, err := s.assetRepository.Upsert(ctx, ast)
+	asset, err := s.assetRepository.Upsert(ctx, ast)
 	// retry due to race condition possibility on insert
 	if errors.Is(err, ErrURNExist) {
-		assetID, err = s.assetRepository.Upsert(ctx, ast)
+		asset, err = s.assetRepository.Upsert(ctx, ast)
 	}
 	if err != nil {
 		return "", err
 	}
 
-	ast.ID = assetID
-	if err := s.worker.EnqueueIndexAssetJob(ctx, *ast); err != nil {
+	if err := s.worker.EnqueueIndexAssetJob(ctx, asset); err != nil {
 		return "", err
 	}
 
-	return assetID, nil
+	return asset.ID, nil
 }
 
 func (s *Service) UpsertPatchAsset(ctx context.Context, ast *Asset, upstreams, downstreams []string, patchData map[string]interface{}) (string, error) {
@@ -141,21 +140,20 @@ func (s *Service) UpsertPatchAssetWithoutLineage(ctx context.Context, ast *Asset
 	currentTime := time.Now()
 	ast.RefreshedAt = &currentTime
 
-	assetID, err := s.assetRepository.UpsertPatch(ctx, ast, patchData)
+	asset, err := s.assetRepository.UpsertPatch(ctx, ast, patchData)
 	// retry due to race condition possibility on insert
 	if errors.Is(err, ErrURNExist) {
-		assetID, err = s.assetRepository.UpsertPatch(ctx, ast, patchData)
+		asset, err = s.assetRepository.UpsertPatch(ctx, ast, patchData)
 	}
 	if err != nil {
 		return "", err
 	}
 
-	ast.ID = assetID
-	if err := s.worker.EnqueueIndexAssetJob(ctx, *ast); err != nil {
+	if err := s.worker.EnqueueIndexAssetJob(ctx, asset); err != nil {
 		return "", err
 	}
 
-	return assetID, nil
+	return asset.ID, nil
 }
 
 func (s *Service) DeleteAsset(ctx context.Context, id string) (err error) {

--- a/core/asset/service.go
+++ b/core/asset/service.go
@@ -116,7 +116,7 @@ func (s *Service) UpsertAssetWithoutLineage(ctx context.Context, ast *Asset) (st
 		return "", err
 	}
 
-	if err := s.worker.EnqueueIndexAssetJob(ctx, asset); err != nil {
+	if err := s.worker.EnqueueIndexAssetJob(ctx, *asset); err != nil {
 		return "", err
 	}
 
@@ -149,7 +149,7 @@ func (s *Service) UpsertPatchAssetWithoutLineage(ctx context.Context, ast *Asset
 		return "", err
 	}
 
-	if err := s.worker.EnqueueIndexAssetJob(ctx, asset); err != nil {
+	if err := s.worker.EnqueueIndexAssetJob(ctx, *asset); err != nil {
 		return "", err
 	}
 

--- a/core/asset/service_test.go
+++ b/core/asset/service_test.go
@@ -194,7 +194,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(asset.Asset{}, errors.New("unknown error"))
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(nil, errors.New("unknown error"))
 			},
 			Err:        errors.New("unknown error"),
 			ReturnedID: "",
@@ -203,7 +203,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Description: `should return error if discovery repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(errors.New("unknown error"))
 			},
 			Err:        errors.New("unknown error"),
@@ -215,7 +215,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Upstreams:   sampleNodes1,
 			Downstreams: sampleNodes2,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 				lr.EXPECT().Upsert(ctx, sampleAsset.URN, sampleNodes1, sampleNodes2).Return(errors.New("unknown error"))
 			},
@@ -228,7 +228,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Upstreams:   sampleNodes1,
 			Downstreams: sampleNodes2,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 				lr.EXPECT().Upsert(ctx, sampleAsset.URN, sampleNodes1, sampleNodes2).Return(nil)
 			},
@@ -279,7 +279,7 @@ func TestService_UpsertAssetWithoutLineage(t *testing.T) {
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(asset.Asset{}, errors.New("unknown error"))
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(nil, errors.New("unknown error"))
 			},
 			Err: errors.New("unknown error"),
 		},
@@ -287,7 +287,7 @@ func TestService_UpsertAssetWithoutLineage(t *testing.T) {
 			Description: `should return error if discovery repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(errors.New("unknown error"))
 			},
 			Err: errors.New("unknown error"),
@@ -296,7 +296,7 @@ func TestService_UpsertAssetWithoutLineage(t *testing.T) {
 			Description: `should return no error if all repositories upsert return no error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 			},
 			ReturnedID: sampleAsset.ID,
@@ -350,7 +350,7 @@ func TestService_UpsertPatchAsset(t *testing.T) {
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, _ *mocks.DiscoveryRepository, _ *mocks.LineageRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(asset.Asset{}, errors.New("unknown error"))
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(nil, errors.New("unknown error"))
 			},
 			Err:        errors.New("unknown error"),
 			ReturnedID: "",
@@ -359,7 +359,7 @@ func TestService_UpsertPatchAsset(t *testing.T) {
 			Description: `should return error if discovery repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, _ *mocks.LineageRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(*sampleAsset, nil)
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(errors.New("unknown error"))
 			},
 			Err:        errors.New("unknown error"),
@@ -371,7 +371,7 @@ func TestService_UpsertPatchAsset(t *testing.T) {
 			Upstreams:   sampleNodes1,
 			Downstreams: sampleNodes2,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(*sampleAsset, nil)
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 				lr.EXPECT().Upsert(ctx, sampleAsset.URN, sampleNodes1, sampleNodes2).Return(errors.New("unknown error"))
 			},
@@ -384,7 +384,7 @@ func TestService_UpsertPatchAsset(t *testing.T) {
 			Upstreams:   sampleNodes1,
 			Downstreams: sampleNodes2,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(*sampleAsset, nil)
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 				lr.EXPECT().Upsert(ctx, sampleAsset.URN, sampleNodes1, sampleNodes2).Return(nil)
 			},
@@ -436,7 +436,7 @@ func TestService_UpsertPatchAssetWithoutLineage(t *testing.T) {
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, _ *mocks.DiscoveryRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(asset.Asset{}, errors.New("unknown error"))
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(nil, errors.New("unknown error"))
 			},
 			Err: errors.New("unknown error"),
 		},
@@ -444,7 +444,7 @@ func TestService_UpsertPatchAssetWithoutLineage(t *testing.T) {
 			Description: `should return error if discovery repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(*sampleAsset, nil)
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(errors.New("unknown error"))
 			},
 			Err: errors.New("unknown error"),
@@ -453,7 +453,7 @@ func TestService_UpsertPatchAssetWithoutLineage(t *testing.T) {
 			Description: `should return no error if all repositories upsert return no error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(*sampleAsset, nil)
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 			},
 			ReturnedID: sampleAsset.ID,

--- a/core/asset/service_test.go
+++ b/core/asset/service_test.go
@@ -194,7 +194,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return("", errors.New("unknown error"))
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(asset.Asset{}, errors.New("unknown error"))
 			},
 			Err:        errors.New("unknown error"),
 			ReturnedID: "",
@@ -203,7 +203,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Description: `should return error if discovery repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset.ID, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(errors.New("unknown error"))
 			},
 			Err:        errors.New("unknown error"),
@@ -215,7 +215,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Upstreams:   sampleNodes1,
 			Downstreams: sampleNodes2,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset.ID, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 				lr.EXPECT().Upsert(ctx, sampleAsset.URN, sampleNodes1, sampleNodes2).Return(errors.New("unknown error"))
 			},
@@ -228,7 +228,7 @@ func TestService_UpsertAsset(t *testing.T) {
 			Upstreams:   sampleNodes1,
 			Downstreams: sampleNodes2,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset.ID, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 				lr.EXPECT().Upsert(ctx, sampleAsset.URN, sampleNodes1, sampleNodes2).Return(nil)
 			},
@@ -279,7 +279,7 @@ func TestService_UpsertAssetWithoutLineage(t *testing.T) {
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return("", errors.New("unknown error"))
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(asset.Asset{}, errors.New("unknown error"))
 			},
 			Err: errors.New("unknown error"),
 		},
@@ -287,7 +287,7 @@ func TestService_UpsertAssetWithoutLineage(t *testing.T) {
 			Description: `should return error if discovery repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset.ID, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(errors.New("unknown error"))
 			},
 			Err: errors.New("unknown error"),
@@ -296,7 +296,7 @@ func TestService_UpsertAssetWithoutLineage(t *testing.T) {
 			Description: `should return no error if all repositories upsert return no error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().Upsert(ctx, sampleAsset).Return(sampleAsset.ID, nil)
+				ar.EXPECT().Upsert(ctx, sampleAsset).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 			},
 			ReturnedID: sampleAsset.ID,
@@ -350,7 +350,7 @@ func TestService_UpsertPatchAsset(t *testing.T) {
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, _ *mocks.DiscoveryRepository, _ *mocks.LineageRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return("", errors.New("unknown error"))
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(asset.Asset{}, errors.New("unknown error"))
 			},
 			Err:        errors.New("unknown error"),
 			ReturnedID: "",
@@ -359,7 +359,7 @@ func TestService_UpsertPatchAsset(t *testing.T) {
 			Description: `should return error if discovery repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, _ *mocks.LineageRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(sampleAsset.ID, nil)
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(errors.New("unknown error"))
 			},
 			Err:        errors.New("unknown error"),
@@ -371,7 +371,7 @@ func TestService_UpsertPatchAsset(t *testing.T) {
 			Upstreams:   sampleNodes1,
 			Downstreams: sampleNodes2,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(sampleAsset.ID, nil)
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 				lr.EXPECT().Upsert(ctx, sampleAsset.URN, sampleNodes1, sampleNodes2).Return(errors.New("unknown error"))
 			},
@@ -384,7 +384,7 @@ func TestService_UpsertPatchAsset(t *testing.T) {
 			Upstreams:   sampleNodes1,
 			Downstreams: sampleNodes2,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository, lr *mocks.LineageRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(sampleAsset.ID, nil)
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 				lr.EXPECT().Upsert(ctx, sampleAsset.URN, sampleNodes1, sampleNodes2).Return(nil)
 			},
@@ -436,7 +436,7 @@ func TestService_UpsertPatchAssetWithoutLineage(t *testing.T) {
 			Description: `should return error if asset repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, _ *mocks.DiscoveryRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return("", errors.New("unknown error"))
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(asset.Asset{}, errors.New("unknown error"))
 			},
 			Err: errors.New("unknown error"),
 		},
@@ -444,7 +444,7 @@ func TestService_UpsertPatchAssetWithoutLineage(t *testing.T) {
 			Description: `should return error if discovery repository upsert return error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(sampleAsset.ID, nil)
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(errors.New("unknown error"))
 			},
 			Err: errors.New("unknown error"),
@@ -453,7 +453,7 @@ func TestService_UpsertPatchAssetWithoutLineage(t *testing.T) {
 			Description: `should return no error if all repositories upsert return no error`,
 			Asset:       sampleAsset,
 			Setup: func(ctx context.Context, ar *mocks.AssetRepository, dr *mocks.DiscoveryRepository) {
-				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(sampleAsset.ID, nil)
+				ar.EXPECT().UpsertPatch(ctx, sampleAsset, mock.Anything).Return(*sampleAsset, nil)
 				dr.EXPECT().Upsert(ctx, mock.AnythingOfType("asset.Asset")).Return(nil)
 			},
 			ReturnedID: sampleAsset.ID,

--- a/internal/store/postgres/asset_repository.go
+++ b/internal/store/postgres/asset_repository.go
@@ -28,11 +28,11 @@ type AssetRepository struct {
 
 // GetAll retrieves list of assets with filters
 func (r *AssetRepository) GetAll(ctx context.Context, flt asset.Filter) ([]asset.Asset, error) {
-	builder := r.getAssetSQL().Offset(uint64(flt.Offset))
+	builder := r.getAssetSQLWithForUpdate().Offset(uint64(flt.Offset))
 	size := flt.Size
 
 	if size > 0 {
-		builder = r.getAssetSQL().Limit(uint64(size)).Offset(uint64(flt.Offset))
+		builder = r.getAssetSQLWithForUpdate().Limit(uint64(size)).Offset(uint64(flt.Offset))
 	}
 	builder = r.BuildFilterQuery(builder, flt)
 	builder = r.buildOrderQuery(builder, flt)
@@ -193,7 +193,7 @@ func (r *AssetRepository) getWithPredicate(ctx context.Context, pred sq.Eq) (ass
 }
 
 func (r *AssetRepository) getWithPredicateWithTx(ctx context.Context, tx *sqlx.Tx, pred sq.Eq) (asset.Asset, error) {
-	query, args, err := r.getAssetSQL().
+	query, args, err := r.getAssetSQLWithForUpdate().
 		Where(pred).
 		Limit(1).
 		PlaceholderFormat(sq.Dollar).
@@ -333,12 +333,12 @@ func (r *AssetRepository) getByVersion(
 // Upsert creates a new asset if it does not exist yet.
 // It updates if asset does exist.
 // Checking existence is done using "urn", "type", "name", "data", and "service" fields.
-func (r *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (assetID string, err error) {
+func (r *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (upsertedAsset asset.Asset, err error) {
 	err = r.client.RunWithinTx(ctx, func(tx *sqlx.Tx) (err error) {
 		fetchedAsset, err := r.GetByURNWithTx(ctx, tx, ast.URN)
 		if errors.As(err, new(asset.NotFoundError)) {
 			// insert flow
-			assetID, err = r.insert(ctx, tx, ast)
+			upsertedAsset, err = r.insert(ctx, tx, ast)
 			if err != nil {
 				return fmt.Errorf("error inserting asset to DB: %w", err)
 			}
@@ -354,18 +354,19 @@ func (r *AssetRepository) Upsert(ctx context.Context, ast *asset.Asset) (assetID
 			return fmt.Errorf("error diffing two assets: %w", err)
 		}
 
-		if err := r.update(ctx, tx, ast, &fetchedAsset, changelog); err != nil {
+		ast.ID = fetchedAsset.ID
+		upsertedAsset, err = r.update(ctx, tx, ast, &fetchedAsset, changelog)
+		if err != nil {
 			return fmt.Errorf("error updating asset to DB: %w", err)
 		}
-		assetID = fetchedAsset.ID
 
 		return nil
 	})
 	if err != nil {
-		return "", err
+		return upsertedAsset, err
 	}
 
-	return assetID, nil
+	return upsertedAsset, nil
 }
 
 // UpsertPatch creates a new asset if it does not exist yet.
@@ -376,7 +377,7 @@ func (r *AssetRepository) UpsertPatch( //nolint:gocognit
 	ctx context.Context,
 	ast *asset.Asset,
 	patchData map[string]interface{},
-) (assetID string, err error) {
+) (upsertedAsset asset.Asset, err error) {
 	err = r.client.RunWithinTx(ctx, func(tx *sqlx.Tx) (err error) {
 		fetchedAsset, err := r.GetByURNWithTx(ctx, tx, ast.URN)
 		if errors.As(err, new(asset.NotFoundError)) {
@@ -384,7 +385,7 @@ func (r *AssetRepository) UpsertPatch( //nolint:gocognit
 			if err := r.validateAsset(*ast); err != nil {
 				return err
 			}
-			assetID, err = r.insert(ctx, tx, ast)
+			upsertedAsset, err = r.insert(ctx, tx, ast)
 			if err != nil {
 				return fmt.Errorf("error inserting asset to DB: %w", err)
 			}
@@ -409,18 +410,18 @@ func (r *AssetRepository) UpsertPatch( //nolint:gocognit
 			return fmt.Errorf("error diffing two assets: %w", err)
 		}
 
-		if err := r.update(ctx, tx, &newAsset, &fetchedAsset, changelog); err != nil {
+		upsertedAsset, err = r.update(ctx, tx, &newAsset, &fetchedAsset, changelog)
+		if err != nil {
 			return fmt.Errorf("error updating asset to DB: %w", err)
 		}
-		assetID = fetchedAsset.ID
 
 		return nil
 	})
 	if err != nil {
-		return "", err
+		return upsertedAsset, err
 	}
 
-	return assetID, nil
+	return upsertedAsset, nil
 }
 
 func (*AssetRepository) validateAsset(ast asset.Asset) error {
@@ -638,55 +639,62 @@ func (r *AssetRepository) deleteWithPredicate(ctx context.Context, pred sq.Eq) (
 	return affectedRows, nil
 }
 
-func (r *AssetRepository) insert(ctx context.Context, tx *sqlx.Tx, ast *asset.Asset) (string, error) {
+func (r *AssetRepository) insert(ctx context.Context, tx *sqlx.Tx, ast *asset.Asset) (asset.Asset, error) {
 	currentTime := time.Now()
 	if ast.RefreshedAt != nil {
 		currentTime = *ast.RefreshedAt
 	}
 	ast.CreatedAt = currentTime
 	ast.UpdatedAt = currentTime
-	query, args, err := sq.Insert("assets").
+	insertCTE := sq.Insert("assets").
 		Columns("urn", "type", "service", "name", "description", "data", "url", "labels",
 			"created_at", "updated_by", "updated_at", "refreshed_at", "version").
 		Values(ast.URN, ast.Type, ast.Service, ast.Name, ast.Description, ast.Data, ast.URL, ast.Labels,
 			ast.CreatedAt, ast.UpdatedBy.ID, ast.UpdatedAt, currentTime, asset.BaseVersion).
-		Suffix("RETURNING \"id\"").
-		PlaceholderFormat(sq.Dollar).
-		ToSql()
+		Suffix("RETURNING *").
+		Prefix("WITH assets AS (").
+		Suffix(")")
+	returnQuery := r.getAssetSQL()
+
+	// Combine CTE and main query
+	fullQuery := returnQuery.PrefixExpr(insertCTE)
+
+	query, args, err := fullQuery.PlaceholderFormat(sq.Dollar).ToSql()
 	if err != nil {
-		return "", fmt.Errorf("build insert query: %w", err)
+		return asset.Asset{}, fmt.Errorf("build insert query: %w", err)
 	}
 
-	ast.Version = asset.BaseVersion
-
-	var id string
-	err = tx.QueryRowContext(ctx, query, args...).Scan(&id)
+	var am AssetModel
+	err = sqlx.GetContext(ctx, tx, &am, query, args...)
 	if err != nil {
 		if strings.Contains(err.Error(), "assets_idx_urn") {
-			return "", asset.ErrURNExist
+			return asset.Asset{}, asset.ErrURNExist
 		}
-
-		return "", fmt.Errorf("run insert query: %w", err)
+		return asset.Asset{}, fmt.Errorf("error executing query: %w", err)
 	}
-	ast.ID = id
 
 	users, err := r.createOrFetchUsers(ctx, tx, ast.Owners)
 	if err != nil {
-		return "", fmt.Errorf("create and fetch owners: %w", err)
+		return asset.Asset{}, fmt.Errorf("create and fetch owners: %w", err)
 	}
-
-	err = r.insertOwners(ctx, tx, ast.ID, users)
+	err = r.insertOwners(ctx, tx, am.ID, users)
 	if err != nil {
-		return "", fmt.Errorf("run insert owners query: %w", err)
+		return asset.Asset{}, fmt.Errorf("run insert owners query: %w", err)
 	}
 
-	return id, r.insertAssetVersion(ctx, tx, ast, diff.Changelog{})
+	insertedAsset := am.toAsset(users)
+
+	if err := r.insertAssetVersion(ctx, tx, &insertedAsset, diff.Changelog{}); err != nil {
+		return asset.Asset{}, err
+	}
+
+	return insertedAsset, nil
 }
 
-func (r *AssetRepository) update(ctx context.Context, tx *sqlx.Tx, newAsset, oldAsset *asset.Asset, clog diff.Changelog) error {
+func (r *AssetRepository) update(ctx context.Context, tx *sqlx.Tx, newAsset, oldAsset *asset.Asset, clog diff.Changelog) (asset.Asset, error) {
 	assetID := oldAsset.ID
 	if !isValidUUID(assetID) {
-		return asset.InvalidError{AssetID: assetID}
+		return asset.Asset{}, asset.InvalidError{AssetID: assetID}
 	}
 
 	currentTime := time.Now()
@@ -698,49 +706,50 @@ func (r *AssetRepository) update(ctx context.Context, tx *sqlx.Tx, newAsset, old
 
 	if len(clog) == 0 {
 		if newAsset.RefreshedAt == nil || newAsset.RefreshedAt == oldAsset.RefreshedAt {
-			return nil
+			return *newAsset, nil
 		}
 
 		return r.updateAssetRefreshedAt(ctx, tx, assetID, currentTime)
 	}
 
+	// managing owners
+	newAssetOwners, err := r.createOrFetchUsers(ctx, tx, newAsset.Owners)
+	if err != nil {
+		return asset.Asset{}, fmt.Errorf("error creating and fetching owners: %w", err)
+	}
+	toInserts, toRemoves := r.compareOwners(oldAsset.Owners, newAssetOwners)
+	if err := r.insertOwners(ctx, tx, assetID, toInserts); err != nil {
+		return asset.Asset{}, fmt.Errorf("error inserting asset's new owners: %w", err)
+	}
+	if err := r.removeOwners(ctx, tx, assetID, toRemoves); err != nil {
+		return asset.Asset{}, fmt.Errorf("error removing asset's old owners: %w", err)
+	}
+
 	// update assets
 	newVersion, err := asset.IncreaseMinorVersion(oldAsset.Version)
 	if err != nil {
-		return err
+		return asset.Asset{}, err
 	}
 	newAsset.Version = newVersion
 	newAsset.ID = assetID
 	newAsset.UpdatedAt = currentTime
 	newAsset.RefreshedAt = &currentTime
 
-	if err := r.updateAsset(ctx, tx, assetID, newAsset); err != nil {
-		return err
+	updatedAsset, err := r.updateAsset(ctx, tx, assetID, newAsset)
+	if err != nil {
+		return asset.Asset{}, err
 	}
 
 	// insert versions
 	if err := r.insertAssetVersion(ctx, tx, newAsset, clog); err != nil {
-		return err
+		return asset.Asset{}, err
 	}
 
-	// managing owners
-	newAssetOwners, err := r.createOrFetchUsers(ctx, tx, newAsset.Owners)
-	if err != nil {
-		return fmt.Errorf("error creating and fetching owners: %w", err)
-	}
-	toInserts, toRemoves := r.compareOwners(oldAsset.Owners, newAssetOwners)
-	if err := r.insertOwners(ctx, tx, assetID, toInserts); err != nil {
-		return fmt.Errorf("error inserting asset's new owners: %w", err)
-	}
-	if err := r.removeOwners(ctx, tx, assetID, toRemoves); err != nil {
-		return fmt.Errorf("error removing asset's old owners: %w", err)
-	}
-
-	return nil
+	return updatedAsset, nil
 }
 
-func (r *AssetRepository) updateAsset(ctx context.Context, tx *sqlx.Tx, assetID string, newAsset *asset.Asset) error {
-	query, args, err := sq.Update("assets").
+func (r *AssetRepository) updateAsset(ctx context.Context, tx *sqlx.Tx, assetID string, newAsset *asset.Asset) (asset.Asset, error) {
+	updateCTE := sq.Update("assets").
 		Set("urn", newAsset.URN).
 		Set("type", newAsset.Type).
 		Set("service", newAsset.Service).
@@ -754,34 +763,58 @@ func (r *AssetRepository) updateAsset(ctx context.Context, tx *sqlx.Tx, assetID 
 		Set("updated_by", newAsset.UpdatedBy.ID).
 		Set("version", newAsset.Version).
 		Where(sq.Eq{"id": assetID}).
-		PlaceholderFormat(sq.Dollar).
-		ToSql()
+		Suffix("RETURNING *").
+		Prefix("WITH assets AS (").
+		Suffix(")")
+	returnQuery := r.getAssetSQL()
+
+	fullQuery := returnQuery.PrefixExpr(updateCTE)
+	query, args, err := fullQuery.PlaceholderFormat(sq.Dollar).ToSql()
 	if err != nil {
-		return fmt.Errorf("build query: %w", err)
+		return asset.Asset{}, fmt.Errorf("build query: %w", err)
 	}
 
-	if err := r.execContext(ctx, tx, query, args...); err != nil {
-		return fmt.Errorf("error running update asset query: %w", err)
+	var am AssetModel
+	err = sqlx.GetContext(ctx, tx, &am, query, args...)
+	if err != nil {
+		return asset.Asset{}, fmt.Errorf("error executing query: %w", err)
 	}
 
-	return nil
+	owners, err := r.getOwnersWithTx(ctx, tx, am.ID)
+	if err != nil {
+		return asset.Asset{}, err
+	}
+
+	return am.toAsset(owners), nil
 }
 
-func (r *AssetRepository) updateAssetRefreshedAt(ctx context.Context, tx *sqlx.Tx, assetID string, currentTime time.Time) error {
-	query, args, err := sq.Update("assets").
+func (r *AssetRepository) updateAssetRefreshedAt(ctx context.Context, tx *sqlx.Tx, assetID string, currentTime time.Time) (asset.Asset, error) {
+	updateCTE := sq.Update("assets").
 		Set("refreshed_at", currentTime).
 		Where(sq.Eq{"id": assetID}).
-		PlaceholderFormat(sq.Dollar).
-		ToSql()
+		Suffix("RETURNING *").
+		Prefix("WITH assets AS (").
+		Suffix(")")
+	returnQuery := r.getAssetSQL()
+
+	fullQuery := returnQuery.PrefixExpr(updateCTE)
+	query, args, err := fullQuery.PlaceholderFormat(sq.Dollar).ToSql()
 	if err != nil {
-		return fmt.Errorf("build query: %w", err)
+		return asset.Asset{}, fmt.Errorf("build query: %w", err)
 	}
 
-	if err := r.execContext(ctx, tx, query, args...); err != nil {
-		return fmt.Errorf("error running update asset query: %w", err)
+	var am AssetModel
+	err = sqlx.GetContext(ctx, tx, &am, query, args...)
+	if err != nil {
+		return asset.Asset{}, fmt.Errorf("error executing query: %w", err)
 	}
 
-	return nil
+	owners, err := r.getOwnersWithTx(ctx, tx, am.ID)
+	if err != nil {
+		return asset.Asset{}, err
+	}
+
+	return am.toAsset(owners), nil
 }
 
 func (r *AssetRepository) insertAssetVersion(ctx context.Context, execer sqlx.ExecerContext, oldAsset *asset.Asset, clog diff.Changelog) error {
@@ -791,6 +824,10 @@ func (r *AssetRepository) insertAssetVersion(ctx context.Context, execer sqlx.Ex
 
 	if clog == nil {
 		return fmt.Errorf("changelog is nil when insert to asset version")
+	}
+
+	if oldAsset.UpdatedBy.ID == "" {
+		return fmt.Errorf("user not found with ID: %s", oldAsset.UpdatedBy.ID)
 	}
 
 	jsonChangelog, err := json.Marshal(clog)
@@ -1023,7 +1060,11 @@ func (r *AssetRepository) getAssetSQL() sq.SelectBuilder {
 		u.updated_at as "updated_by.updated_at"
 		`).
 		From("assets a").
-		LeftJoin("users u ON a.updated_by = u.id").
+		LeftJoin("users u ON a.updated_by = u.id")
+}
+
+func (r *AssetRepository) getAssetSQLWithForUpdate() sq.SelectBuilder {
+	return r.getAssetSQL().
 		Suffix("FOR UPDATE OF a")
 }
 

--- a/internal/store/postgres/asset_repository_test.go
+++ b/internal/store/postgres/asset_repository_test.go
@@ -119,11 +119,10 @@ func (r *AssetRepositoryTestSuite) insertRecord() (assets []asset.Asset) {
 			UpdatedBy:   r.users[0],
 		}
 
-		id, err := r.repository.Upsert(r.ctx, &ast)
+		insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(id)
-		ast.ID = id
-		assets = append(assets, ast)
+		r.Require().NotEmpty(insertedAsset.ID)
+		assets = append(assets, insertedAsset)
 	}
 
 	return assets
@@ -213,7 +212,7 @@ func (r *AssetRepositoryTestSuite) TestBuildFilterQuery() {
 }
 
 func (r *AssetRepositoryTestSuite) TestGetAll() {
-	assets := r.insertRecord()
+	r.BeforeTest("", "")
 
 	r.Run("should return error if SortBy key is invalid", func() {
 		_, err := r.repository.GetAll(r.ctx, asset.Filter{
@@ -230,7 +229,7 @@ func (r *AssetRepositoryTestSuite) TestGetAll() {
 		r.Require().NoError(err)
 		r.Require().Len(results, expectedSize)
 		for i := 0; i < expectedSize; i++ {
-			r.assertAsset(&assets[i], &results[i])
+			r.assertAsset(&r.assets[i], &results[i])
 		}
 	})
 
@@ -243,7 +242,7 @@ func (r *AssetRepositoryTestSuite) TestGetAll() {
 		r.Require().NoError(err)
 		r.Require().Len(results, size)
 		for i := 0; i < size; i++ {
-			r.assertAsset(&assets[i], &results[i])
+			r.assertAsset(&r.assets[i], &results[i])
 		}
 	})
 
@@ -255,7 +254,7 @@ func (r *AssetRepositoryTestSuite) TestGetAll() {
 		})
 		r.Require().NoError(err)
 		for i := offset; i > len(results)+offset; i++ {
-			r.assertAsset(&assets[i], &results[i-offset])
+			r.assertAsset(&r.assets[i], &results[i-offset])
 		}
 	})
 
@@ -400,7 +399,7 @@ func (r *AssetRepositoryTestSuite) TestGetAll() {
 }
 
 func (r *AssetRepositoryTestSuite) TestGetTypes() {
-	_ = r.insertRecord()
+	r.BeforeTest("", "")
 
 	type testCase struct {
 		Description string
@@ -563,10 +562,9 @@ func (r *AssetRepositoryTestSuite) TestGetCount() {
 			Service:   service[0],
 			UpdatedBy: r.users[0],
 		}
-		id, err := r.repository.Upsert(r.ctx, &ast)
+		insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(id)
-		ast.ID = id
+		r.Require().NotEmpty(insertedAsset.ID)
 	}
 
 	r.Run("should return total assets with filter", func() {
@@ -609,20 +607,18 @@ func (r *AssetRepositoryTestSuite) TestGetByID() {
 		}
 
 		var err error
-		id, err := r.repository.Upsert(r.ctx, &asset1)
+		insertedAsset, err := r.repository.Upsert(r.ctx, &asset1)
 		r.Require().NoError(err)
-		r.NotEmpty(id)
-		asset1.ID = id
+		r.NotEmpty(insertedAsset.ID)
 
-		id, err = r.repository.Upsert(r.ctx, &asset2)
+		insertedAsset2, err := r.repository.Upsert(r.ctx, &asset2)
 		r.Require().NoError(err)
-		r.NotEmpty(id)
-		asset2.ID = id
+		r.NotEmpty(insertedAsset2.ID)
 
-		result, err := r.repository.GetByID(r.ctx, asset2.ID)
+		result, err := r.repository.GetByID(r.ctx, insertedAsset2.ID)
 		r.NoError(err)
 		asset2.UpdatedBy = r.users[1]
-		r.assertAsset(&asset2, &result)
+		r.assertAsset(&insertedAsset2, &result)
 	})
 
 	r.Run("return owners if any", func() {
@@ -637,12 +633,11 @@ func (r *AssetRepositoryTestSuite) TestGetByID() {
 			UpdatedBy: r.users[1],
 		}
 
-		id, err := r.repository.Upsert(r.ctx, &ast)
+		insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(id)
-		ast.ID = id
+		r.Require().NotEmpty(insertedAsset.ID)
 
-		result, err := r.repository.GetByID(r.ctx, ast.ID)
+		result, err := r.repository.GetByID(r.ctx, insertedAsset.ID)
 		r.NoError(err)
 		r.Len(result.Owners, len(ast.Owners))
 		for i, owner := range result.Owners {
@@ -674,19 +669,17 @@ func (r *AssetRepositoryTestSuite) TestGetByURN() {
 			UpdatedBy: r.users[1],
 		}
 
-		id, err := r.repository.Upsert(r.ctx, &asset1)
+		insertedAsset, err := r.repository.Upsert(r.ctx, &asset1)
 		r.Require().NoError(err)
-		r.NotEmpty(id)
-		asset1.ID = id
+		r.NotEmpty(insertedAsset.ID)
 
-		id, err = r.repository.Upsert(r.ctx, &asset2)
+		insertedAsset2, err := r.repository.Upsert(r.ctx, &asset2)
 		r.Require().NoError(err)
-		r.NotEmpty(id)
-		asset2.ID = id
+		r.NotEmpty(insertedAsset2.ID)
 
 		result, err := r.repository.GetByURN(r.ctx, "urn-gbi-2")
 		r.NoError(err)
-		r.assertAsset(&asset2, &result)
+		r.assertAsset(&insertedAsset2, &result)
 	})
 
 	r.Run("return owners if any", func() {
@@ -725,16 +718,16 @@ func (r *AssetRepositoryTestSuite) TestVersions() {
 		RefreshedAt: &currentTime,
 	}
 
-	id, err := r.repository.Upsert(r.ctx, &astVersioning)
+	insertedAsset, err := r.repository.Upsert(r.ctx, &astVersioning)
 	r.Require().NoError(err)
-	r.Require().NotEmpty(id)
-	astVersioning.ID = id
+	r.Require().NotEmpty(insertedAsset.ID)
+	astVersioning.ID = insertedAsset.ID
 
 	// v0.2
 	astVersioning.Description = "new description in v0.2"
-	id, err = r.repository.Upsert(r.ctx, &astVersioning)
+	upsertedAsset, err := r.repository.Upsert(r.ctx, &astVersioning)
 	r.Require().NoError(err)
-	r.Require().Equal(id, astVersioning.ID)
+	r.Require().Equal(upsertedAsset.ID, astVersioning.ID)
 
 	// v0.3
 	astVersioning.Owners = []user.User{
@@ -746,26 +739,26 @@ func (r *AssetRepositoryTestSuite) TestVersions() {
 			Provider: "meteor",
 		},
 	}
-	id, err = r.repository.Upsert(r.ctx, &astVersioning)
+	upsertedAsset, err = r.repository.Upsert(r.ctx, &astVersioning)
 	r.Require().NoError(err)
-	r.Require().Equal(id, astVersioning.ID)
+	r.Require().Equal(upsertedAsset.ID, astVersioning.ID)
 
 	// v0.4
 	astVersioning.Data = map[string]interface{}{
 		"data1": float64(12345),
 	}
-	id, err = r.repository.Upsert(r.ctx, &astVersioning)
+	upsertedAsset, err = r.repository.Upsert(r.ctx, &astVersioning)
 	r.Require().NoError(err)
-	r.Require().Equal(id, astVersioning.ID)
+	r.Require().Equal(upsertedAsset.ID, astVersioning.ID)
 
 	// v0.5
 	astVersioning.Labels = map[string]string{
 		"key1": "value1",
 	}
 
-	id, err = r.repository.Upsert(r.ctx, &astVersioning)
+	upsertedAsset, err = r.repository.Upsert(r.ctx, &astVersioning)
 	r.Require().NoError(err)
-	r.Require().Equal(id, astVersioning.ID)
+	r.Require().Equal(upsertedAsset.ID, astVersioning.ID)
 
 	r.Run("should return current version of an assets", func() {
 		expected := asset.Asset{
@@ -896,16 +889,16 @@ func (r *AssetRepositoryTestSuite) TestVersions() {
 			Service:   "bigquery",
 			UpdatedBy: r.users[1],
 		}
-		id, err := r.repository.Upsert(r.ctx, &ast)
+		insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(id)
-		ast.ID = id
+		r.Require().NotEmpty(insertedAsset.ID)
+		ast.ID = insertedAsset.ID
 
 		for i := 2; i < 100; i++ {
 			ast.Description = "new description in v0." + strconv.Itoa(i)
-			id, err = r.repository.Upsert(r.ctx, &ast)
+			upsertedAsset, err = r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.Require().Equal(id, ast.ID)
+			r.Require().Equal(upsertedAsset.ID, ast.ID)
 		}
 
 		expected := []asset.Asset{
@@ -962,16 +955,16 @@ func (r *AssetRepositoryTestSuite) TestVersions() {
 			Service:   "bigquery",
 			UpdatedBy: r.users[1],
 		}
-		id, err := r.repository.Upsert(r.ctx, &ast)
+		insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(id)
-		ast.ID = id
+		r.Require().NotEmpty(insertedAsset.ID)
+		ast.ID = insertedAsset.ID
 
 		for i := 2; i < 100; i++ {
 			ast.Description = "new description in v0." + strconv.Itoa(i)
-			id, err = r.repository.Upsert(r.ctx, &ast)
+			upsertedAsset, err = r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.Require().Equal(id, ast.ID)
+			r.Require().Equal(upsertedAsset.ID, ast.ID)
 		}
 
 		assetVersions, err := r.repository.GetVersionHistory(r.ctx, asset.Filter{Size: 0, Offset: 86}, ast.ID)
@@ -999,19 +992,18 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				UpdatedBy:   r.users[0],
 				RefreshedAt: &refreshedAtTime,
 			}
-			id, err := r.repository.Upsert(r.ctx, &ast)
-			r.Equal(asset.BaseVersion, ast.Version)
+			insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
+			r.Equal(asset.BaseVersion, insertedAsset.Version)
 			r.NoError(err)
-			r.NotEmpty(id)
+			r.NotEmpty(insertedAsset.ID)
 			r.NotEmpty(ast.CreatedAt)
 			r.NotEmpty(ast.UpdatedAt)
-			ast.ID = id
+			r.NotEqual(time.Time{}, insertedAsset.CreatedAt)
+			r.NotEqual(time.Time{}, insertedAsset.UpdatedAt)
 
-			assetInDB, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.Require().NoError(err)
-			r.NotEqual(time.Time{}, assetInDB.CreatedAt)
-			r.NotEqual(time.Time{}, assetInDB.UpdatedAt)
-			r.assertAsset(&ast, &assetInDB)
+			ast.ID = insertedAsset.ID
+			ast.Version = asset.BaseVersion
+			r.assertAsset(&ast, &insertedAsset)
 
 			ast2 := ast
 			ast2.RefreshedAt = nil
@@ -1037,17 +1029,12 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				UpdatedBy: r.users[0],
 			}
 
-			id, err := r.repository.Upsert(r.ctx, &ast)
+			insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.Require().NotEmpty(id)
-			ast.ID = id
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-
-			r.Len(actual.Owners, 2)
-			r.Equal(r.users[1].ID, actual.Owners[0].ID)
-			r.Equal(r.users[2].ID, actual.Owners[1].ID)
+			r.Require().NotEmpty(insertedAsset.ID)
+			r.Len(insertedAsset.Owners, 2)
+			r.Equal(r.users[1].ID, insertedAsset.Owners[0].ID)
+			r.Equal(r.users[2].ID, insertedAsset.Owners[1].ID)
 		})
 
 		r.Run("should create owners as users if they do not exist yet", func() {
@@ -1063,15 +1050,11 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				UpdatedBy: r.users[0],
 			}
 
-			id, err := r.repository.Upsert(r.ctx, &ast)
+			insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-
-			actual, err := r.repository.GetByID(r.ctx, id)
-			r.NoError(err)
-
-			r.Len(actual.Owners, 2)
-			r.Equal(ast.Owners[0].Email, actual.Owners[0].Email)
+			r.NotEmpty(insertedAsset.ID)
+			r.Len(insertedAsset.Owners, 2)
+			r.Equal(ast.Owners[0].Email, insertedAsset.Owners[0].Email)
 		})
 	})
 
@@ -1087,18 +1070,16 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 			}
 			identicalAsset := ast
 
-			id, err := r.repository.Upsert(r.ctx, &ast)
+			insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			ast.ID = id
+			r.NotEmpty(insertedAsset.ID)
 
-			id, err = r.repository.Upsert(r.ctx, &identicalAsset)
+			identicalAssetResult, err := r.repository.Upsert(r.ctx, &identicalAsset)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			identicalAsset.ID = id
+			r.NotEmpty(identicalAssetResult.ID)
 
-			r.Equal(ast.ID, identicalAsset.ID)
-			r.Equal(ast.Version, identicalAsset.Version)
+			r.Equal(insertedAsset.ID, identicalAssetResult.ID)
+			r.Equal(identicalAssetResult.Version, identicalAssetResult.Version)
 		})
 
 		r.Run("should same asset version if asset only has different at RefreshedAt", func() {
@@ -1113,26 +1094,20 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				Version:     "0.1",
 			}
 
-			id, err := r.repository.Upsert(r.ctx, &ast)
+			insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			ast.ID = id
+			r.NotEmpty(insertedAsset.ID)
+			ast.ID = insertedAsset.ID
 
 			updated := ast
 			updated.RefreshedAt = &refreshedAtTime
 
-			id, err = r.repository.Upsert(r.ctx, &updated)
+			upsertedAsset, err := r.repository.Upsert(r.ctx, &updated)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			updated.ID = id
-
-			r.Equal(ast.ID, updated.ID)
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-
-			r.Equal(updated.RefreshedAt, actual.RefreshedAt)
-			r.Equal(ast.Version, actual.Version)
+			r.NotEmpty(upsertedAsset.ID)
+			r.Equal(insertedAsset.ID, upsertedAsset.ID)
+			r.Equal(updated.RefreshedAt, upsertedAsset.RefreshedAt)
+			r.Equal(ast.Version, upsertedAsset.Version)
 		})
 
 		r.Run("should update the asset version if asset is not identical", func() {
@@ -1145,26 +1120,20 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				Version:   "0.1",
 			}
 
-			id, err := r.repository.Upsert(r.ctx, &ast)
+			insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			ast.ID = id
+			r.NotEmpty(insertedAsset.ID)
+			ast.ID = insertedAsset.ID
 
 			updated := ast
 			updated.URL = "https://sample-url.com"
 
-			id, err = r.repository.Upsert(r.ctx, &updated)
+			upsertedAsset, err := r.repository.Upsert(r.ctx, &updated)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			updated.ID = id
-
-			r.Equal(ast.ID, updated.ID)
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-
-			r.Equal(updated.URL, actual.URL)
-			r.NotEqual(ast.Version, actual.Version)
+			r.NotEmpty(upsertedAsset.ID)
+			r.Equal(insertedAsset.ID, upsertedAsset.ID)
+			r.Equal(updated.URL, upsertedAsset.URL)
+			r.NotEqual(ast.Version, upsertedAsset.Version)
 		})
 
 		r.Run("should delete old owners if it does not exist on new asset", func() {
@@ -1183,20 +1152,15 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				stripUserID(r.users[2]),
 			}
 
-			id, err := r.repository.Upsert(r.ctx, &ast)
+			insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			ast.ID = id
+			r.NotEmpty(insertedAsset.ID)
 
-			id, err = r.repository.Upsert(r.ctx, &newAsset)
+			upsertedAsset, err := r.repository.Upsert(r.ctx, &newAsset)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			newAsset.ID = id
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-			r.Len(actual.Owners, len(newAsset.Owners))
-			r.Equal(r.users[2].ID, actual.Owners[0].ID)
+			r.NotEmpty(upsertedAsset.ID)
+			r.Len(upsertedAsset.Owners, len(newAsset.Owners))
+			r.Equal(r.users[2].ID, upsertedAsset.Owners[0].ID)
 		})
 
 		r.Run("should create new owners if it does not exist on old asset", func() {
@@ -1215,21 +1179,16 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				stripUserID(r.users[2]),
 			}
 
-			id, err := r.repository.Upsert(r.ctx, &ast)
+			insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			ast.ID = id
+			r.NotEmpty(insertedAsset.ID)
 
-			id, err = r.repository.Upsert(r.ctx, &newAsset)
+			upsertedAsset, err := r.repository.Upsert(r.ctx, &newAsset)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			newAsset.ID = id
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-			r.Len(actual.Owners, len(newAsset.Owners))
-			r.Equal(r.users[1].ID, actual.Owners[0].ID)
-			r.Equal(r.users[2].ID, actual.Owners[1].ID)
+			r.NotEmpty(upsertedAsset.ID)
+			r.Len(upsertedAsset.Owners, len(newAsset.Owners))
+			r.Equal(r.users[1].ID, upsertedAsset.Owners[0].ID)
+			r.Equal(r.users[2].ID, upsertedAsset.Owners[1].ID)
 		})
 
 		r.Run("should create users from owners if owner emails do not exist yet", func() {
@@ -1248,23 +1207,18 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 				{Email: "newuser@example.com"},
 			}
 
-			id, err := r.repository.Upsert(r.ctx, &ast)
+			insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			ast.ID = id
+			r.NotEmpty(insertedAsset.ID)
 
-			id, err = r.repository.Upsert(r.ctx, &newAsset)
+			upsertedAsset, err := r.repository.Upsert(r.ctx, &newAsset)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			newAsset.ID = id
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-			r.Len(actual.Owners, len(newAsset.Owners))
-			r.NotEmpty(actual.Owners[0].ID)
-			r.Equal(r.users[1].ID, actual.Owners[0].ID)
-			r.NotEmpty(actual.Owners[1].ID)
-			r.Equal(newAsset.Owners[1].Email, actual.Owners[1].Email)
+			r.NotEmpty(insertedAsset.ID)
+			r.Len(upsertedAsset.Owners, len(newAsset.Owners))
+			r.NotEmpty(upsertedAsset.Owners[0].ID)
+			r.Equal(r.users[1].ID, upsertedAsset.Owners[0].ID)
+			r.NotEmpty(upsertedAsset.Owners[1].ID)
+			r.Equal(newAsset.Owners[1].Email, upsertedAsset.Owners[1].Email)
 		})
 	})
 }
@@ -1280,9 +1234,9 @@ func (r *AssetRepositoryTestSuite) TestUpsertRaceCondition() {
 			Version:   "0.1",
 		}
 
-		id, err := r.repository.Upsert(r.ctx, &ast)
+		insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
-		r.NotEmpty(id)
+		r.NotEmpty(insertedAsset.ID)
 
 		const numGoroutines = 10 // Number of concurrent upserts
 		var wg sync.WaitGroup
@@ -1343,15 +1297,12 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 				},
 			}
 
-			id, err := r.repository.UpsertPatch(r.ctx, &ast, patchData)
+			insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, patchData)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-
-			actual, err := r.repository.GetByID(r.ctx, id)
-			r.NoError(err)
-			r.NotEqual("gotocompany", actual.Data["entity"])
-			r.Equal("gojek", actual.Data["entity"])
-			r.Equal(map[string]interface{}{"foo": "bar"}, actual.Data["data"])
+			r.NotEmpty(insertedAsset.ID)
+			r.NotEqual("gotocompany", insertedAsset.Data["entity"])
+			r.Equal("gojek", insertedAsset.Data["entity"])
+			r.Equal(map[string]interface{}{"foo": "bar"}, insertedAsset.Data["data"])
 		})
 
 		r.Run("set ID to asset and version to base version", func() {
@@ -1368,19 +1319,18 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 				RefreshedAt: &refreshedAtTime,
 			}
 
-			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
-			r.Equal(asset.BaseVersion, ast.Version)
+			insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+			r.Equal(asset.BaseVersion, insertedAsset.Version)
 			r.NoError(err)
-			r.NotEmpty(id)
+			r.NotEmpty(insertedAsset.ID)
 			r.NotEmpty(ast.CreatedAt)
 			r.NotEmpty(ast.UpdatedAt)
-			ast.ID = id
+			r.NotEqual(time.Time{}, insertedAsset.CreatedAt)
+			r.NotEqual(time.Time{}, insertedAsset.UpdatedAt)
 
-			assetInDB, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.Require().NoError(err)
-			r.NotEqual(time.Time{}, assetInDB.CreatedAt)
-			r.NotEqual(time.Time{}, assetInDB.UpdatedAt)
-			r.assertAsset(&ast, &assetInDB)
+			ast.ID = insertedAsset.ID
+			ast.Version = asset.BaseVersion
+			r.assertAsset(&ast, &insertedAsset)
 
 			// Same with ast1
 			ast2 := asset.Asset{
@@ -1423,17 +1373,12 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 				UpdatedBy: r.users[0],
 			}
 
-			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+			insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
 			r.Require().NoError(err)
-			r.Require().NotEmpty(id)
-			ast.ID = id
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-
-			r.Len(actual.Owners, 2)
-			r.Equal(r.users[1].ID, actual.Owners[0].ID)
-			r.Equal(r.users[2].ID, actual.Owners[1].ID)
+			r.Require().NotEmpty(insertedAsset.ID)
+			r.Len(insertedAsset.Owners, 2)
+			r.Equal(r.users[1].ID, insertedAsset.Owners[0].ID)
+			r.Equal(r.users[2].ID, insertedAsset.Owners[1].ID)
 		})
 
 		r.Run("should create owners as users if they do not exist yet", func() {
@@ -1453,15 +1398,11 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 				UpdatedBy: r.users[0],
 			}
 
-			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+			insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-
-			actual, err := r.repository.GetByID(r.ctx, id)
-			r.NoError(err)
-
-			r.Len(actual.Owners, 2)
-			r.Equal(ast.Owners[0].Email, actual.Owners[0].Email)
+			r.NotEmpty(insertedAsset.ID)
+			r.Len(insertedAsset.Owners, 2)
+			r.Equal(ast.Owners[0].Email, insertedAsset.Owners[0].Email)
 		})
 	})
 
@@ -1481,24 +1422,22 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 			}
 			identicalAsset := ast
 
-			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
+			insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			ast.ID = id
+			r.NotEmpty(insertedAsset.ID)
 
 			patchData := make(map[string]interface{})
 			patchData["data"] = map[string]interface{}{
 				"entity": "gotocompany",
 			}
 
-			id, err = r.repository.UpsertPatch(r.ctx, &identicalAsset, patchData) // update
+			upsertedAsset, err := r.repository.UpsertPatch(r.ctx, &identicalAsset, patchData) // update
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			identicalAsset.ID = id
+			r.NotEmpty(upsertedAsset.ID)
 
-			r.Equal(ast.ID, identicalAsset.ID)
-			r.Equal(ast.Version, identicalAsset.Version)
-			r.Equal(identicalAsset.Data["entity"], "gotocompany")
+			r.Equal(insertedAsset.ID, upsertedAsset.ID)
+			r.Equal(insertedAsset.Version, upsertedAsset.Version)
+			r.Equal(upsertedAsset.Data["entity"], "gotocompany")
 		})
 
 		r.Run("should same asset version if asset only has different at RefreshedAt", func() {
@@ -1517,10 +1456,10 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 				Version:     "0.1",
 			}
 
-			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
+			insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			ast.ID = id
+			r.NotEmpty(insertedAsset.ID)
+			ast.ID = insertedAsset.ID
 
 			updated := ast
 			updated.RefreshedAt = &refreshedAtTime
@@ -1529,19 +1468,15 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 				"entity": "gotocompany",
 			}
 
-			id, err = r.repository.UpsertPatch(r.ctx, &updated, patchData) // update
+			upsertedAsset, err := r.repository.UpsertPatch(r.ctx, &updated, patchData) // update
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			updated.ID = id
+			r.NotEmpty(upsertedAsset.ID)
+			updated.ID = upsertedAsset.ID
 
-			r.Equal(ast.ID, updated.ID)
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-
-			r.Equal(updated.RefreshedAt, actual.RefreshedAt)
-			r.Equal(ast.Version, actual.Version)
-			r.Equal(actual.Data["entity"], "gotocompany")
+			r.Equal(insertedAsset.ID, upsertedAsset.ID)
+			r.Equal(updated.RefreshedAt, upsertedAsset.RefreshedAt)
+			r.Equal(insertedAsset.Version, upsertedAsset.Version)
+			r.Equal(upsertedAsset.Data["entity"], "gotocompany")
 		})
 
 		r.Run("should update the asset version if asset is not identical", func() {
@@ -1562,10 +1497,10 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 				Version:   "0.1",
 			}
 
-			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
+			insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			ast.ID = id
+			r.NotEmpty(insertedAsset.ID)
+			ast.ID = insertedAsset.ID
 
 			updated := ast
 			updated.Description = "bluffing"
@@ -1577,20 +1512,16 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 			}
 			updated.Patch(patchData)
 
-			id, err = r.repository.UpsertPatch(r.ctx, &updated, patchData) // update
+			upsertedAsset, err := r.repository.UpsertPatch(r.ctx, &updated, patchData) // update
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			updated.ID = id
+			r.NotEmpty(upsertedAsset.ID)
+			updated.ID = upsertedAsset.ID
 
-			r.Equal(ast.ID, updated.ID)
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-
-			r.Equal("existing", actual.Description)
-			r.Equal("gotocompany", actual.Data["entity"])
-			r.Equal(map[string]interface{}{"foo": "new"}, actual.Data["data"])
-			r.NotEqual(ast.Version, actual.Version)
+			r.Equal(insertedAsset.ID, upsertedAsset.ID)
+			r.Equal("existing", upsertedAsset.Description)
+			r.Equal("gotocompany", upsertedAsset.Data["entity"])
+			r.Equal(map[string]interface{}{"foo": "new"}, upsertedAsset.Data["data"])
+			r.NotEqual(ast.Version, upsertedAsset.Version)
 		})
 
 		r.Run("should keep old data if it does not exist on new asset", func() {
@@ -1612,24 +1543,21 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 				stripUserID(r.users[2]),
 			}
 
-			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
+			insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
 			r.Require().NoError(err)
-			r.NotEmpty(id)
+			r.NotEmpty(insertedAsset.ID)
 
 			patchData := make(map[string]interface{})
 			patchData["data"] = map[string]interface{}{
 				"another": "things",
 			}
 
-			id, err = r.repository.UpsertPatch(r.ctx, &newAsset, patchData) // update
+			upsertedAsset, err := r.repository.UpsertPatch(r.ctx, &newAsset, patchData) // update
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-			r.Len(actual.Data, 2)
-			r.Equal(actual.Data["entity"], "gotocompany")
-			r.Equal(actual.Data["another"], "things")
+			r.NotEmpty(upsertedAsset.ID)
+			r.Len(upsertedAsset.Data, 2)
+			r.Equal(upsertedAsset.Data["entity"], "gotocompany")
+			r.Equal(upsertedAsset.Data["another"], "things")
 		})
 
 		r.Run("should delete old owners if it does not exist on new patch", func() {
@@ -1648,10 +1576,10 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 			}
 			newAsset := ast
 
-			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+			insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-			ast.ID = id
+			r.NotEmpty(insertedAsset.ID)
+			ast.ID = insertedAsset.ID
 
 			patchData := make(map[string]interface{})
 			patchData["owners"] = []map[string]interface{}{
@@ -1662,14 +1590,11 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 				},
 			}
 
-			id, err = r.repository.UpsertPatch(r.ctx, &newAsset, patchData)
+			upsertedAsset, err := r.repository.UpsertPatch(r.ctx, &newAsset, patchData)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-			r.Len(actual.Owners, len(newAsset.Owners))
-			r.Equal(r.users[2].ID, actual.Owners[0].ID)
+			r.NotEmpty(upsertedAsset.ID)
+			r.Len(upsertedAsset.Owners, len(newAsset.Owners))
+			r.Equal(r.users[2].ID, upsertedAsset.Owners[0].ID)
 		})
 
 		r.Run("should create new owners if it does not exist on old asset", func() {
@@ -1688,9 +1613,9 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 			}
 			newAsset := ast
 
-			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+			insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
+			r.NotEmpty(insertedAsset.ID)
 
 			patchData := make(map[string]interface{})
 			patchData["owners"] = []map[string]interface{}{
@@ -1706,15 +1631,12 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 				},
 			}
 
-			id, err = r.repository.UpsertPatch(r.ctx, &newAsset, patchData)
+			upsertedAsset, err := r.repository.UpsertPatch(r.ctx, &newAsset, patchData)
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-			r.Len(actual.Owners, 2)
-			r.Equal(r.users[1].ID, actual.Owners[0].ID)
-			r.Equal(r.users[2].ID, actual.Owners[1].ID)
+			r.NotEmpty(upsertedAsset.ID)
+			r.Len(upsertedAsset.Owners, 2)
+			r.Equal(r.users[1].ID, upsertedAsset.Owners[0].ID)
+			r.Equal(r.users[2].ID, upsertedAsset.Owners[1].ID)
 		})
 
 		r.Run("should create users from owners if owner emails do not exist yet", func() {
@@ -1733,9 +1655,9 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 			}
 			newAsset := ast
 
-			id, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
+			insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, nil) // insert
 			r.Require().NoError(err)
-			r.NotEmpty(id)
+			r.NotEmpty(insertedAsset)
 
 			patchData := make(map[string]interface{})
 			patchData["owners"] = []map[string]interface{}{
@@ -1749,16 +1671,13 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 				},
 			}
 
-			id, err = r.repository.UpsertPatch(r.ctx, &newAsset, patchData) // update
+			upsertedAsset, err := r.repository.UpsertPatch(r.ctx, &newAsset, patchData) // update
 			r.Require().NoError(err)
-			r.NotEmpty(id)
-
-			actual, err := r.repository.GetByID(r.ctx, ast.ID)
-			r.NoError(err)
-			r.Len(actual.Owners, 2)
-			r.NotEmpty(actual.Owners[0].ID)
-			r.Equal(r.users[1].ID, actual.Owners[0].ID)
-			r.NotEmpty(actual.Owners[1].ID)
+			r.NotEmpty(upsertedAsset)
+			r.Len(upsertedAsset.Owners, 2)
+			r.NotEmpty(upsertedAsset.Owners[0].ID)
+			r.Equal(r.users[1].ID, upsertedAsset.Owners[0].ID)
+			r.NotEmpty(upsertedAsset.Owners[1].ID)
 		})
 	})
 }
@@ -1778,9 +1697,9 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatchRaceCondition() {
 			Version:   "0.1",
 		}
 
-		id, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
+		insertedAsset, err := r.repository.UpsertPatch(r.ctx, &ast, nil)
 		r.Require().NoError(err)
-		r.NotEmpty(id)
+		r.NotEmpty(insertedAsset.ID)
 
 		const numGoroutines = 10 // Number of concurrent upserts
 		var wg sync.WaitGroup
@@ -1833,26 +1752,26 @@ func (r *AssetRepositoryTestSuite) TestDeleteByID() {
 			URN:       "urn-del-1",
 			Type:      "table",
 			Service:   "bigquery",
-			UpdatedBy: user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy: r.users[0],
 		}
 		asset2 := asset.Asset{
 			URN:       "urn-del-2",
 			Type:      "topic",
 			Service:   "kafka",
 			Version:   asset.BaseVersion,
-			UpdatedBy: user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy: r.users[0],
 		}
 
 		var err error
-		id, err := r.repository.Upsert(r.ctx, &asset1)
+		insertedAsset, err := r.repository.Upsert(r.ctx, &asset1)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(id)
-		asset1.ID = id
+		r.Require().NotEmpty(insertedAsset.ID)
+		asset1.ID = insertedAsset.ID
 
-		id, err = r.repository.Upsert(r.ctx, &asset2)
+		insertedAsset2, err := r.repository.Upsert(r.ctx, &asset2)
 		r.Require().NoError(err)
-		r.Require().NotEmpty(id)
-		asset2.ID = id
+		r.Require().NotEmpty(insertedAsset2.ID)
+		asset2.ID = insertedAsset2.ID
 
 		err = r.repository.DeleteByID(r.ctx, asset1.ID)
 		r.NoError(err)
@@ -1882,20 +1801,20 @@ func (r *AssetRepositoryTestSuite) TestDeleteByURN() {
 			URN:       "urn-del-1",
 			Type:      "table",
 			Service:   "bigquery",
-			UpdatedBy: user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy: r.users[0],
 		}
 		asset2 := asset.Asset{
 			URN:       "urn-del-2",
 			Type:      "topic",
 			Service:   "kafka",
 			Version:   asset.BaseVersion,
-			UpdatedBy: user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy: r.users[0],
 		}
 
 		_, err := r.repository.Upsert(r.ctx, &asset1)
 		r.Require().NoError(err)
 
-		id, err := r.repository.Upsert(r.ctx, &asset2)
+		insertedAsset2, err := r.repository.Upsert(r.ctx, &asset2)
 		r.Require().NoError(err)
 
 		err = r.repository.DeleteByURN(r.ctx, asset1.URN)
@@ -1906,7 +1825,7 @@ func (r *AssetRepositoryTestSuite) TestDeleteByURN() {
 
 		asset2FromDB, err := r.repository.GetByURN(r.ctx, asset2.URN)
 		r.NoError(err)
-		r.Equal(id, asset2FromDB.ID)
+		r.Equal(insertedAsset2.ID, asset2FromDB.ID)
 
 		// cleanup
 		err = r.repository.DeleteByURN(r.ctx, asset2.URN)
@@ -1922,7 +1841,7 @@ func (r *AssetRepositoryTestSuite) TestDeleteByQueryExpr() {
 			URN:         "urn-del-1",
 			Type:        "table",
 			Service:     "bigquery",
-			UpdatedBy:   user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy:   r.users[0],
 			RefreshedAt: &oneYearAgoRefreshedAtTime,
 		}
 		asset2 := asset.Asset{
@@ -1930,14 +1849,14 @@ func (r *AssetRepositoryTestSuite) TestDeleteByQueryExpr() {
 			Type:        "topic",
 			Service:     "kafka",
 			Version:     asset.BaseVersion,
-			UpdatedBy:   user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy:   r.users[0],
 			RefreshedAt: &oneYearAgoRefreshedAtTime,
 		}
 
 		_, err := r.repository.Upsert(r.ctx, &asset1)
 		r.Require().NoError(err)
 
-		id, err := r.repository.Upsert(r.ctx, &asset2)
+		insertedAsset2, err := r.repository.Upsert(r.ctx, &asset2)
 		r.Require().NoError(err)
 
 		query := "refreshed_at <= '" + refreshedAtTime.Format("2006-01-02T15:04:05Z") +
@@ -1957,7 +1876,7 @@ func (r *AssetRepositoryTestSuite) TestDeleteByQueryExpr() {
 
 		asset2FromDB, err := r.repository.GetByURN(r.ctx, asset2.URN)
 		r.NoError(err)
-		r.Equal(id, asset2FromDB.ID)
+		r.Equal(insertedAsset2.ID, asset2FromDB.ID)
 
 		// cleanup
 		err = r.repository.DeleteByURN(r.ctx, asset2.URN)
@@ -1980,7 +1899,7 @@ func (r *AssetRepositoryTestSuite) TestAddProbe() {
 			URN:       "urn-add-probe-1",
 			Type:      typeJob,
 			Service:   "airflow",
-			UpdatedBy: user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy: r.users[0],
 		}
 		probeID := uuid.NewString()
 		probe := asset.Probe{
@@ -2009,7 +1928,7 @@ func (r *AssetRepositoryTestSuite) TestAddProbe() {
 			URN:       "urn-add-probe-1",
 			Type:      typeJob,
 			Service:   "airflow",
-			UpdatedBy: user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy: r.users[0],
 		}
 		probe := asset.Probe{
 			Status:       "COMPLETED",
@@ -2056,7 +1975,7 @@ func (r *AssetRepositoryTestSuite) TestAddProbe() {
 			URN:       "urn-add-probe-1",
 			Type:      typeJob,
 			Service:   "airflow",
-			UpdatedBy: user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy: r.users[0],
 		}
 		probeID := uuid.NewString()
 		probe := asset.Probe{
@@ -2083,13 +2002,13 @@ func (r *AssetRepositoryTestSuite) TestAddProbe() {
 			URN:       "urn-add-probe-2",
 			Type:      typeJob,
 			Service:   "optimus",
-			UpdatedBy: user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy: r.users[0],
 		}
 		otherAst := asset.Asset{
 			URN:       "urn-add-probe-3",
 			Type:      typeJob,
 			Service:   "airflow",
-			UpdatedBy: user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy: r.users[0],
 		}
 		probe := asset.Probe{
 			Status: "RUNNING",
@@ -2136,7 +2055,7 @@ func (r *AssetRepositoryTestSuite) TestGetProbes() {
 			URN:       "urn-add-probe-1",
 			Type:      asset.Type("job"),
 			Service:   "airflow",
-			UpdatedBy: user.User{ID: defaultAssetUpdaterUserID},
+			UpdatedBy: r.users[0],
 		}
 		p1 := asset.Probe{
 			Status:    "COMPLETED",

--- a/internal/store/postgres/asset_repository_test.go
+++ b/internal/store/postgres/asset_repository_test.go
@@ -122,7 +122,7 @@ func (r *AssetRepositoryTestSuite) insertRecord() (assets []asset.Asset) {
 		insertedAsset, err := r.repository.Upsert(r.ctx, &ast)
 		r.Require().NoError(err)
 		r.Require().NotEmpty(insertedAsset.ID)
-		assets = append(assets, insertedAsset)
+		assets = append(assets, *insertedAsset)
 	}
 
 	return assets
@@ -618,7 +618,7 @@ func (r *AssetRepositoryTestSuite) TestGetByID() {
 		result, err := r.repository.GetByID(r.ctx, insertedAsset2.ID)
 		r.NoError(err)
 		asset2.UpdatedBy = r.users[1]
-		r.assertAsset(&insertedAsset2, &result)
+		r.assertAsset(insertedAsset2, &result)
 	})
 
 	r.Run("return owners if any", func() {
@@ -679,7 +679,7 @@ func (r *AssetRepositoryTestSuite) TestGetByURN() {
 
 		result, err := r.repository.GetByURN(r.ctx, "urn-gbi-2")
 		r.NoError(err)
-		r.assertAsset(&insertedAsset2, &result)
+		r.assertAsset(insertedAsset2, &result)
 	})
 
 	r.Run("return owners if any", func() {
@@ -1003,7 +1003,7 @@ func (r *AssetRepositoryTestSuite) TestUpsert() {
 
 			ast.ID = insertedAsset.ID
 			ast.Version = asset.BaseVersion
-			r.assertAsset(&ast, &insertedAsset)
+			r.assertAsset(&ast, insertedAsset)
 
 			ast2 := ast
 			ast2.RefreshedAt = nil
@@ -1330,7 +1330,7 @@ func (r *AssetRepositoryTestSuite) TestUpsertPatch() {
 
 			ast.ID = insertedAsset.ID
 			ast.Version = asset.BaseVersion
-			r.assertAsset(&ast, &insertedAsset)
+			r.assertAsset(&ast, insertedAsset)
 
 			// Same with ast1
 			ast2 := asset.Asset{
@@ -2484,6 +2484,16 @@ func (r *AssetRepositoryTestSuite) insertProbes(t *testing.T) {
 }
 
 func (r *AssetRepositoryTestSuite) assertAsset(expectedAsset, actualAsset *asset.Asset) bool {
+	if expectedAsset == nil && actualAsset == nil {
+		return true
+	}
+	if expectedAsset == nil {
+		return false
+	}
+	if actualAsset == nil {
+		return false
+	}
+
 	// sanitize time to make the assets comparable
 	expectedAsset.CreatedAt = time.Time{}
 	expectedAsset.UpdatedAt = time.Time{}

--- a/internal/store/postgres/postgres_test.go
+++ b/internal/store/postgres/postgres_test.go
@@ -64,12 +64,11 @@ func createUser(userRepo user.Repository, email string) (string, error) {
 func createAsset(assetRepo asset.Repository, updaterID, ownerEmail, assetURN, assetType string) (*asset.Asset, error) {
 	ast := getAsset(ownerEmail, assetURN, assetType)
 	ast.UpdatedBy.ID = updaterID
-	id, err := assetRepo.Upsert(context.Background(), ast)
+	insertedAsset, err := assetRepo.Upsert(context.Background(), ast)
 	if err != nil {
 		return nil, err
 	}
-	ast.ID = id
-	return ast, nil
+	return &insertedAsset, nil
 }
 
 func getAsset(ownerEmail, assetURN, assetType string) *asset.Asset {

--- a/internal/store/postgres/postgres_test.go
+++ b/internal/store/postgres/postgres_test.go
@@ -68,7 +68,7 @@ func createAsset(assetRepo asset.Repository, updaterID, ownerEmail, assetURN, as
 	if err != nil {
 		return nil, err
 	}
-	return &insertedAsset, nil
+	return insertedAsset, nil
 }
 
 func getAsset(ownerEmail, assetURN, assetType string) *asset.Asset {

--- a/internal/store/postgres/star_repository_test.go
+++ b/internal/store/postgres/star_repository_test.go
@@ -107,19 +107,6 @@ func (r *StarRepositoryTestSuite) TestCreate() {
 		r.ErrorIs(err, star.DuplicateRecordError{UserID: userID, AssetID: createdAsset.ID})
 		r.Empty(id)
 	})
-
-	r.Run("return error user not found if user does not exist", func() {
-		err := testutils.RunMigrationsWithClient(r.T(), r.client)
-		r.NoError(err)
-		uid := uuid.NewString()
-
-		createdAsset, err := createAsset(r.assetRepository, uid, ownerEmail, "asset-urn-1", "table")
-		r.NoError(err)
-
-		id, err := r.repository.Create(r.ctx, uid, createdAsset.ID)
-		r.ErrorIs(err, star.UserNotFoundError{UserID: uid})
-		r.Empty(id)
-	})
 }
 
 func (r *StarRepositoryTestSuite) TestGetStargazers() {


### PR DESCRIPTION
The UpsertPatch API currently has a bug that causes Elasticsearch data to be replaced instead of patched when requests are sent with only some fields. As a result, any fields not included in the request will be set to zero values in Elasticsearch.

The problem can arise if we manually invoke the API with incomplete request fields.

AC:
- Able to send requests containing only specific fields without inadvertently introducing incorrect values in both the database and Elasticsearch.

